### PR TITLE
Bump version

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,6 +1,21 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
-# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
-on: [push, pull_request]
+# Modifications:
+# - removed 'branches: [main, master]' below 'push: ' to run GHA on all branches.
+# - added 'schedule: - cron: "23 4 * * 6"' to run every Saturday on 04:23 (UTC)
+# - added 'workflow_dispatch: ' at 'on:' to be able to manually trigger GHA (see
+#   https://docs.github.com/en/actions/reference/workflows-and-actions and
+#   https://docs.github.com/en/actions/how-tos/manage-workflow-runs).
+# - added {os: ubuntu-latest,   r: '4.0.0'} to run GHA for R version 4.0.0.
+
+# Need help debugging build failures? Start at
+# https://github.com/r-lib/actions#where-to-find-help
+
+on:
+  push:
+  pull_request:
+  schedule:
+      - cron: "23 4 * * 6" # run GHA every Saturday on 04:23 (UTC)
+  workflow_dispatch: # to be able to manually trigger GHA
 
 name: R-CMD-check.yaml
 
@@ -18,9 +33,10 @@ jobs:
         config:
           - {os: macos-latest,   r: 'release'}
           - {os: windows-latest, r: 'release'}
-          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
-          - {os: ubuntu-latest,   r: 'release'}
-          - {os: ubuntu-latest,   r: 'oldrel-1'}
+          - {os: ubuntu-latest,  r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-latest,  r: 'release'}
+          - {os: ubuntu-latest,  r: 'oldrel-1'}
+          - {os: ubuntu-latest,  r: '4.0.0'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -32,7 +32,9 @@ jobs:
       matrix:
         config:
           - {os: macos-latest,   r: 'release'}
+          - {os: macos-latest,   r: '4.1.0'}
           - {os: windows-latest, r: 'release'}
+          - {os: windows-latest, r: '4.1.0'}
           - {os: ubuntu-latest,  r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,  r: 'release'}
           - {os: ubuntu-latest,  r: 'oldrel-1'}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,11 +1,12 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Modifications:
-# - removed 'branches: [main, master]' below 'push: ' to run GHA on all branches.
-# - added 'schedule: - cron: "23 4 * * 6"' to run every Saturday on 04:23 (UTC)
-# - added 'workflow_dispatch: ' at 'on:' to be able to manually trigger GHA (see
+# - run GHA on all branches: removed 'branches: [main, master]' below 'push:'
+# - run GHA every Saturday on 04:23 UTC: added 'schedule: - cron: "23 4 * * 6"'
+# - enable manually triggering GHA: added 'workflow_dispatch:' at 'on:' (see
 #   https://docs.github.com/en/actions/reference/workflows-and-actions and
 #   https://docs.github.com/en/actions/how-tos/manage-workflow-runs).
-# - added {os: ubuntu-latest,   r: '4.1.0'} to run GHA for R version 4.1.0.
+# - run GHA with R version 4.1.0 (miniimum version used as dependency) for
+#   macos, windows, and ubuntu.
 
 # Need help debugging build failures? Start at
 # https://github.com/r-lib/actions#where-to-find-help
@@ -37,7 +38,6 @@ jobs:
           - {os: windows-latest, r: '4.1.0'}
           - {os: ubuntu-latest,  r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,  r: 'release'}
-          - {os: ubuntu-latest,  r: 'oldrel-1'}
           - {os: ubuntu-latest,  r: '4.1.0'}
 
     env:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -5,7 +5,7 @@
 # - added 'workflow_dispatch: ' at 'on:' to be able to manually trigger GHA (see
 #   https://docs.github.com/en/actions/reference/workflows-and-actions and
 #   https://docs.github.com/en/actions/how-tos/manage-workflow-runs).
-# - added {os: ubuntu-latest,   r: '4.0.0'} to run GHA for R version 4.0.0.
+# - added {os: ubuntu-latest,   r: '4.1.0'} to run GHA for R version 4.1.0.
 
 # Need help debugging build failures? Start at
 # https://github.com/r-lib/actions#where-to-find-help
@@ -36,7 +36,7 @@ jobs:
           - {os: ubuntu-latest,  r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,  r: 'release'}
           - {os: ubuntu-latest,  r: 'oldrel-1'}
-          - {os: ubuntu-latest,  r: '4.0.0'}
+          - {os: ubuntu-latest,  r: '4.1.0'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,4 +19,4 @@ URL: https://github.com/JesseAlderliesten/checkinput
 BugReports: https://github.com/JesseAlderliesten/checkinput/issues
 VignetteBuilder: knitr
 Depends: 
-    R (>= 4.0.0)
+    R (>= 4.1.0)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: checkinput
 Title: Check Function Input
-Version: 0.3.1
+Version: 0.4.0
 Authors@R: 
     person("Jesse", "Alderliesten", email = "jessealderliesten@hotmail.com",
     role = c("aut", "cre"), comment = c(ORCID = "0000-0003-1132-4310"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,9 +11,10 @@
   `all(x > 0, na.rm = TRUE)` for more succinct and more uniform code.
 
 ### Miscellaneous
-- GitHub action `check-standard` now also runs on R 4.0.0, is triggered every
-  Saturday on 04:23 UTC, and can be triggered manually (trigger it once manually
-  on the main branch to be able to trigger it manually on other branches).
+- GitHub action `check-standard` now also runs on R 4.1.0 on macos, windows, and
+  ubuntu, is triggered every Saturday on 04:23 UTC, and can be triggered
+  manually (trigger it once manually on the main branch to be able to trigger it
+  manually on other branches).
 
 
 # checkinput 0.3.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,12 @@
 - `is_nonnegative()`, `all_nonnegative()`, `is_positive()`: call `is_number()`
   or `all_numbers()` followed by `all(x >= 0, na.rm = TRUE)` or
   `all(x > 0, na.rm = TRUE)` for more succinct and more uniform code.
-  
+
+### Miscellaneous
+- GitHub action `check-standard` now also runs on R 4.0.0, is triggered every
+  Saturday on 04:23 UTC, and can be triggered manually (trigger it once manually
+  on the main branch to be able to trigger it manually on other branches).
+
 
 # checkinput 0.3.1
 `checkinput` now uses GitHub action `check-standard` on all branches.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# devel
+# checkinput 0.4.0
 
 ### Breaking changes
 - Dependency `R` >= 4.0.0 changed to `R` >= 4.1.0, which is required to pass the

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
+# devel
+- `all_names()`: wrap text of warnings. Use `deparse1(substitute(x))` to get the
+  offending values instead of `x` in the text of warnings or errors.
+- `is_nonnegative()`, `all_nonnegative()`, `is_positive()`: call `is_number()`
+  or `all_numbers()` followed by `all(x >= 0, na.rm = TRUE)` or
+  `all(x > 0, na.rm = TRUE)` for more succinct and more uniform code.
+  
+
 # checkinput 0.3.1
 `checkinput` now uses GitHub action `check-standard` on all branches.
+
 
 # checkinput 0.3.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,9 @@
 # devel
+
+### Breaking changes
+- Dependency `R` >= 4.0.0 changed to `R` >= 4.1.0, which is required to pass the
+  R CMD check on ubuntu-latest: `rmarkdown` > `bslib` > `sass` > `fs` needs
+  `R` >= 4.1 and `rappdirs` needs `R` >= 4.1.
 - `all_names()`: wrap text of warnings. Use `deparse1(substitute(x))` to get the
   offending values instead of `x` in the text of warnings or errors.
 - `is_nonnegative()`, `all_nonnegative()`, `is_positive()`: call `is_number()`

--- a/R/all_names.R
+++ b/R/all_names.R
@@ -138,7 +138,7 @@ all_names <- function(x, allow_underscores = TRUE) {
 
   # 'NULL' is catched later on with an informative message
   if(!is.null(x) && (!is.atomic(x) || !is.null(dim(x)) || !is.character(x))) {
-    warning("'x' is not a character vector!")
+    warning("Input to 'x' is not a character vector: ", deparse1(substitute(x)))
     return(FALSE)
   }
 
@@ -152,8 +152,8 @@ all_names <- function(x, allow_underscores = TRUE) {
   if(length(x) == 0L) {
     if(is.null(x)) {
       warn_text_zerolength <- paste0(
-        "'x' is NULL: did you pass names() or colnames() used on an object",
-        "  without (column) names to all_names()?")
+        "'x' is NULL: did you use names() or colnames() on an object without\n",
+        "(column) names to all_names()?")
     } else {
       warn_text_zerolength <- "x has length zero but is not NULL"
     }
@@ -225,7 +225,7 @@ all_names <- function(x, allow_underscores = TRUE) {
     if(any(bool_underscores)) {
       warn_text_underscores <- paste0(
         "contain underscores (which are not allowed if 'allow_underscores' is",
-        " FALSE): ", paste_quoted(x[bool_underscores]))
+        " FALSE):\n", paste_quoted(x[bool_underscores]))
       suggest_make_names <- TRUE
       # Removing names that contain underscores because they are invalid, and
       # thus not suspicious, if 'allow_underscores' is FALSE.

--- a/R/is_number.R
+++ b/R/is_number.R
@@ -70,10 +70,11 @@
 #' @export
 is_number <- function(x, allow_zero = FALSE, allow_NA = FALSE,
                       allow_NaN = FALSE) {
+  length_x <- length(x)
   # is.null(dim(x)) is needed to return `FALSE` for matrices with a single value.
   is.numeric(x) && is.atomic(x) && is.null(dim(x)) &&
-    ((allow_zero && length(x) == 0L) ||
-       (length(x) == 1L &&
+    ((allow_zero && length_x == 0L) ||
+       (length_x == 1L &&
           (allow_NA || !any(is.na(x) & !is.nan(x))) &&
           (allow_NaN || !any(is.nan(x)))))
 }
@@ -82,10 +83,11 @@ is_number <- function(x, allow_zero = FALSE, allow_NA = FALSE,
 #' @export
 all_numbers <- function(x, allow_zero = FALSE, allow_NA = FALSE,
                         allow_NaN = FALSE) {
+  length_x <- length(x)
   # is.null(dim(x)) is needed to return `FALSE` for matrices with a single value.
   is.numeric(x) && is.atomic(x) && is.null(dim(x)) &&
-    ((allow_zero && length(x) == 0L) ||
-       (length(x) >= 1L &&
+    ((allow_zero && length_x == 0L) ||
+       (length_x >= 1L &&
           (allow_NA || !any(is.na(x) & !is.nan(x))) &&
           (allow_NaN || !any(is.nan(x)))))
 }
@@ -94,54 +96,25 @@ all_numbers <- function(x, allow_zero = FALSE, allow_NA = FALSE,
 #' @export
 is_nonnegative <- function(x, allow_zero = FALSE, allow_NA = FALSE,
                            allow_NaN = FALSE) {
-  length_x <- length(x)
-  # is.null(dim(x)) is needed to return `FALSE` for matrices with a single value.
-  ok_p1 <- is.numeric(x) && is.atomic(x) && is.null(dim(x)) &&
-    length_x <= 1L && (allow_zero || length_x == 1L)
-
-  if(ok_p1) {
-    if(length_x == 1L) {
-      is_NA_x <- is.na(x)
-      is_NaN_x <- is.nan(x)
-      ok_p2 <- allow_NaN || !is_NaN_x
-      ok_p3 <- allow_NA || !is_NA_x || is_NaN_x
-      ok_p2 && ok_p3 && (is_NA_x || x >= 0)
-    } else {
-      TRUE
-    }
-  } else {
-    FALSE
-  }
+  is_number(x, allow_zero = allow_zero, allow_NA = allow_NA,
+            allow_NaN = allow_NaN) &&
+    all(x >= 0, na.rm = TRUE)
 }
 
 #' @rdname is_number
 #' @export
 all_nonnegative <- function(x, allow_zero = FALSE, allow_NA = FALSE,
                             allow_NaN = FALSE) {
-  # is.null(dim(x)) is needed to return `FALSE` for matrices with a single value.
-  is.numeric(x) && is.atomic(x) && is.null(dim(x)) &&
-    ((allow_zero && length(x) == 0L) ||
-       (length(x) > 0L &&
-          (allow_NA || !any(is.na(x) & !is.nan(x))) &&
-          (allow_NaN || !any(is.nan(x))) &&
-          all(x >= 0, na.rm = TRUE)))
+  all_numbers(x, allow_zero = allow_zero, allow_NA = allow_NA,
+              allow_NaN = allow_NaN) &&
+    all(x >= 0, na.rm = TRUE)
 }
 
 #' @rdname is_number
 #' @export
 is_positive <- function(x, allow_zero = FALSE, allow_NA = FALSE,
                         allow_NaN = FALSE) {
-  length_x <- length(x)
-  # is.null(dim(x)) is needed to return `FALSE` for matrices with a single value.
-  ok_p1 <- is.numeric(x) && is.atomic(x) && is.null(dim(x)) &&
-    length_x <= 1L && (allow_zero || length_x == 1L)
-
-  if(ok_p1) {
-    is_NA_x <- is.na(x)
-    is_NaN_x <- is.nan(x)
-    length_x == 0L || ((allow_NaN || !is_NaN_x) && (allow_NA || !is_NA_x || is_NaN_x) &&
-                         all(x > 0, na.rm = TRUE))
-  } else {
-    FALSE
-  }
+  is_number(x = x, allow_zero = allow_zero, allow_NA = allow_NA,
+            allow_NaN = allow_NaN) &&
+    all(x > 0, na.rm = TRUE)
 }

--- a/inst/tinytest/test_all_names.R
+++ b/inst/tinytest/test_all_names.R
@@ -78,7 +78,7 @@ warn_dupl <- "are duplicated: "
 warn_suspicious <- "Names are suspicious: "
 warn_syntax <- "are syntactically invalid: "
 warn_undersc <- paste0("contain underscores (which are not allowed if",
-                       " 'allow_underscores' is FALSE): ")
+                       " 'allow_underscores' is FALSE):\n")
 note_mknm_dots <- paste0("\n(it does not recognise names that consist of only",
                          " dots, or two dots followed by digits)")
 
@@ -124,7 +124,7 @@ expect_warning(
 
 expect_warning(
   expect_false(all_names(13)),
-  pattern = "'x' is not a character vector", strict = TRUE, fixed = TRUE)
+  pattern = "'x' is not a character vector: 13", strict = TRUE, fixed = TRUE)
 
 
 #### Test some sets ####
@@ -161,13 +161,14 @@ for(x in list(NA, data.frame(a = "nco"), as.matrix(data.frame(a = "nco")),
               list(a = 314), list(), 314)) {
   expect_warning(
     expect_false(all_names(x = x)),
-    pattern = "'x' is not a character vector!", strict = TRUE, fixed = TRUE)
+    pattern = "Input to 'x' is not a character vector: x", strict = TRUE, fixed = TRUE)
 }
 
 ##### Zero-length values #####
 expect_warning(
   expect_false(all_names(x = NULL)),
-  pattern = "'x' is NULL", strict = TRUE, fixed = TRUE)
+  pattern = "'x' is NULL: did you use names() or colnames() on an object without",
+  strict = TRUE, fixed = TRUE)
 
 expect_warning(
   expect_false(all_names(x = character(0))),


### PR DESCRIPTION
### Breaking changes
- Dependency `R` >= 4.0.0 changed to `R` >= 4.1.0, which is required to pass the
  R CMD check on ubuntu-latest: `rmarkdown` > `bslib` > `sass` > `fs` needs
  `R` >= 4.1 and `rappdirs` needs `R` >= 4.1.
- `all_names()`: wrap text of warnings. Use `deparse1(substitute(x))` to get the
  offending values instead of `x` in the text of warnings or errors.
- `is_nonnegative()`, `all_nonnegative()`, `is_positive()`: call `is_number()`
  or `all_numbers()` followed by `all(x >= 0, na.rm = TRUE)` or
  `all(x > 0, na.rm = TRUE)` for more succinct and more uniform code.

### Miscellaneous
- GitHub action `check-standard` now also runs on R 4.1.0 on macos, windows, and
  ubuntu, is triggered every Saturday on 04:23 UTC, and can be triggered
  manually (trigger it once manually on the main branch to be able to trigger it
  manually on other branches).