### PR TITLE
Add GitHub Action to check without the Suggests dependencies

### DIFF
--- a/.github/workflows/check-no-suggests.yaml
+++ b/.github/workflows/check-no-suggests.yaml
@@ -1,0 +1,79 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+
+# NOTE: This workflow only directly installs "hard" dependencies, i.e. Depends,
+# Imports, and LinkingTo dependencies. Notably, Suggests dependencies are never
+# installed, with the exception of testthat, knitr, and rmarkdown. The cache is
+# never used to avoid accidentally restoring a cache containing a suggested
+# dependency.
+
+# Modifications:
+# - not run GHA on 'push': it should be sufficient to run R CMD check locally
+#   before pushing and run GHA on pull requests.
+# - run GHA every Saturday on 04:23 UTC: added 'schedule: - cron: "23 4 * * 6"'
+# - enable manually triggering GHA: added 'workflow_dispatch:' at 'on:' (see
+#   https://docs.github.com/en/actions/reference/workflows-and-actions and
+#   https://docs.github.com/en/actions/how-tos/manage-workflow-runs).
+# - run GHA with R version 4.1.0 (miniimum version used as dependency) for
+#   macos, windows, and ubuntu.
+
+# Need help debugging build failures? Start at
+# https://github.com/r-lib/actions#where-to-find-help
+
+on:
+  pull_request:
+  schedule:
+      - cron: "23 4 * * 6" # run GHA every Saturday on 04:23 (UTC)
+  workflow_dispatch: # to be able to manually trigger GHA
+
+name: check-no-suggests.yaml
+
+permissions: read-all
+
+jobs:
+  check-no-suggests:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: macos-latest,   r: 'release'}
+          - {os: macos-latest,   r: '4.1.0'}
+          - {os: windows-latest, r: 'release'}
+          - {os: windows-latest, r: '4.1.0'}
+          - {os: ubuntu-latest,  r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-latest,  r: 'release'}
+          - {os: ubuntu-latest,  r: '4.1.0'}
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          dependencies: '"hard"'
+          cache: false
+          extra-packages: |
+            any::rcmdcheck
+            any::testthat
+            any::knitr
+            any::rmarkdown
+          needs: check
+
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-snapshots: true
+          build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'


### PR DESCRIPTION
Add GitHub Action to check that package functions without the dependencies listed in 'Suggests' installed (except testthat, knitr, and rmarkdown).