### PR TITLE
checkinput 0.7.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: checkinput
 Title: Check Function Input
-Version: 0.6.5
+Version: 0.7.0
 Authors@R: 
     person("Jesse", "Alderliesten", email = "jessealderliesten@hotmail.com",
     role = c("aut", "cre"), comment = c(ORCID = "0000-0003-1132-4310"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# checkinput devel
+# checkinput 0.7.0
 
 ### Breaking changes
 - `make_natural()`: change default `all` from `TRUE` to `FALSE` because it will

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,38 +1,27 @@
+# checkinput devel
+
+### Breaking changes
+- `make_natural()`: change default `all` from `TRUE` to `FALSE` because it will
+  be used more often with scalar input.
+
+
 # checkinput 0.6.5
 
-### Miscellaneous
+### Documentation
 - `paste_quoted()`: clearer title and description.
-- Stylistic changes to vignettes.
-- Align `README` with vignette text.
 
 
 # checkinput 0.6.4
 
-### Miscellaneous
+### Documentation
 - Vignette `design_choices`: shorten name to `Design choices`.
-- Fix links to vignettes. Stylistic updates to function documentation.
-
-
-# checkinput 0.6.3
-
-### Miscellaneous
-- Stylistic updates to vignette and website.
+- Fix links to vignettes.
 
 
 # checkinput 0.6.2
 
-### Miscellaneous
-- `README`: refer to website when appropriate. Stylistic update.
-- `NEWS`: stylistic update.
+### Documentation
 - Vignettes: explain notation. Rely on `pkgdown` to create links to functions.
-- `check-no-suggests.yaml`: also mention package `rcmdcheck` as needed package.
-  Order packages alphabetically. Fuller annotation of modifications.
-
-
-# checkinput 0.6.1
-
-### Miscellaneous
-- Add pkgdown website: `https://jessealderliesten.github.io/checkinput/`.
 
 
 # checkinput 0.6.0
@@ -41,9 +30,6 @@
 - Use `roxygen2` version 8.0.0.
 - Replace the non-exported function `paste_quoted()` by the full function from
   `progutils::paste_quoted()` and export it.
-
-### Miscellaneous
-- Stylistic changes to code and tests prompted by `goodpractice::gp()`.
 
 
 # checkinput 0.5.0
@@ -67,16 +53,6 @@
   or `all_numbers()` followed by `all(x >= 0, na.rm = TRUE)` or
   `all(x > 0, na.rm = TRUE)` for more succinct and uniform code.
 
-### Miscellaneous
-- GitHub action `check-standard` also runs on R 4.1.0 on macOS, Windows, and
-  Ubuntu, is triggered every Saturday on 04:23 UTC, and can be triggered
-  manually (trigger it once manually on the main branch to be able to trigger it
-  manually on other branches).
-
-
-# checkinput 0.3.1
-`checkinput` uses GitHub action `check-standard` on all branches.
-
 
 # checkinput 0.3.0
 
@@ -96,18 +72,17 @@
   with default `FALSE`, in contrast to the previous implicit default `TRUE`.
 
 ### Added functions
-- `is_natural`: as `all_natural()` but also test if `x` has a length of at most
-  one.
+- `is_natural`: as `all_natural()` but test if `x` has a length of at most one.
 
 
 # checkinput 0.1.0
 
-### Updated documentation
+### Documentation
 - Vignettes: add hyperlinks from the vignettes to the help-pages of functions.
   No need to put output in comments because the output is automatically shown
   together with the code. Use `<funcname>` instead of `<func>` or `<function>`
   to align with usage in the vignettes of `checkrpkgs`. 
-- README: use `<funcname>` instead of `<func>` or `<function>` to align with
+- `README`: use `<funcname>` instead of `<func>` or `<function>` to align with
   usage in the vignettes of `checkrpkgs`. Define variables to write more
   succinct code.
 
@@ -115,6 +90,8 @@
 # checkinput 0.0.6
 
 ### Breaking changes
+- Added `vctrs` as dependency in `Suggests` because it is used in documentation
+  of `all_names()`.
 - `all_names()`: remove argument `allow_susp` and never allows suspicious names
   because allowing them amounts to only checking for syntactically invalid names,
   for which `make.names()` can be used directly; do not try to identify which
@@ -125,41 +102,24 @@
   checks are now more specific: they check that names which apparently have been
   made valid indeed contain an invalid part, and that the first digit of numbers
   added to duplicated names is non-zero.
-- `is_number()` and derived functions gained arguments `allow_zero`, `allow_NA`
-  and `allow_NaN` (with default `FALSE` in contrast to the previously implicit
+- `is_number()` and derived functions gain arguments `allow_zero`, `allow_NA`
+  and `allow_NaN` (with default `FALSE`, in contrast to the previously implicit
   `TRUE`), to resolve the contradiction that using `is_number()` returned `TRUE`
   for these values but using them in conditional statements led to `logical(0)`
   and thus to an error.
 
-### Updated documentation
-- Added `vctrs` as dependency in `Suggests` because it is used in documentation
-  of `all_names()`.
+### Documentation
 - `all_names()`: major updates and restructuring. Also updated and added examples.
-- `all_natural()`: add a note about functions named `integerish`.
 - `README`: add a reference to my repository `checkrpkgs`. Clarify that
-  functions *do* throw errors about invalid input to arguments other than `x`.
-- Vignette `design_choices`: clarified that functions *do* throw errors about
-  invalid input to arguments other than `x`. Added a table of contents. Removed
-  obsolete note about `allow_NA` being absent from `is_number()` and derived
-  functions.
-- Vignette `Type_Coercion`: rename to `type_coercion`. Added section labels and
-  a table of contents.
-- Replace section title `Note` (created through `@Note`) by section title `Notes`
-  (created through `@section Notes:`). Idem for `Programming note`.
+  functions **do** throw errors about invalid input to arguments other than `x`.
+- Vignette `design_choices`: clarified that functions **do** throw errors about
+  invalid input to arguments other than `x`.
 
 
 # checkinput 0.0.5
 
-### Breaking changes
-- `paste_quoted()` (an internal function) throws an error if `x` has dimensions.
-
-### Minor improvements
-- Move code of `is_character.R` to `all_characters.R`, and code of
-  `is_positive.R`, `is_nonnegative.R`, etc. to `is.number.R`.
-
-### Updated documentation
-- Update `README` to mention vignettes and introduce design choices.
-- Cross-reference on `is_number()` instead of on `all_nonnegative()`.
+### Documentation
+- `README`: mention vignettes and introduce design choices.
 - Remove `Notes` about legacy code.
 - Move `To do` points and `Wishlist` to GitHub issues.
 - Move information about correct input to the vignette `design_choices` that is
@@ -168,7 +128,7 @@
   sections are also mentioned in the `README`.
 - `all_names()`: `data.frame()` also calls `make.names()`. Move section on how
   to get a boolean vector to the vignette on design choices.
-- `is_zerolength()`: document that a zero-row `data.frame` is not a zero-length
+- `is_zerolength()`: document that a zero-row data frame is not a zero-length
   object.
 
 

--- a/R/all_names.R
+++ b/R/all_names.R
@@ -28,7 +28,7 @@
 #' syntactically invalid by [make.names()].
 #'
 #' Suspicious names are not allowed by `all_names()`. A suspicious name contains
-#' a pattern that suggests it originally was syntactically invalid and has been
+#' a pattern suggesting it originally was syntactically invalid and has been
 #' **adjusted** into a syntactically valid name, or has been adjusted to make names
 #' [unique][make.unique()]. Such adjustments usually occur silently, for example
 #' when data is read into \R, which is problematic because it cannot reliably be
@@ -46,8 +46,8 @@
 #'   letter, number, dot or underscore): `make.names()` and
 #'   `vctrs::vec_as_names(x, repair = "universal")` replace such characters with
 #'   a dot. Their identification is based on the assumption that names
-#'   originally did **not** contain dots, which is good practice (unfortunately
-#'   not strictly followed in base-\R, e.g., in [data.frame()]) preventing names
+#'   originally did **not** contain dots, which is good practice (despite not
+#'   being strictly followed in base-\R, e.g., in [data.frame()]) preventing names
 #'   containing a dot from being confused with [methods][UseMethod] used on
 #'   [classed objects][is.object].
 #' - adjustments to make duplicated names unique: `make.names(x, unique = TRUE)`
@@ -62,20 +62,20 @@
 #'   not followed by a number, syntactically valid: `make.names()` prepends `X`;
 #'   `vctrs::vec_as_names(x, repair = "universal")` prepends one or more dots.
 #' - adjustments to name unnamed columns: `data.frame()` uses pattern `V1`,
-#'   `V2`, `V3` if a matrix without column names is converted to a data.frame,
+#'   `V2`, `V3` if a matrix without column names is converted to a data frame,
 #'   and `read.csv(..., header = FALSE)` uses the same pattern for data without
 #'   column names; `read.csv(..., header = TRUE)` uses pattern `X`, `X.1`, `X.2`.
 #'
 #' Names containing underscores (`_`) are by default **allowed** by `all_names()`
 #' because names containing underscores are not syntactically invalid. However,
-#' setting `allow_underscores` to `FALSE` to not allow such names is useful to
-#' check that names do not contain underscores, for example if several names
+#' setting `allow_underscores` to `FALSE` to **not** allow such names is useful
+#' to check that names do not contain underscores, for example if several names
 #' will be concatenated to create an ID-tag, separating the parts by underscores.
 #'
 #' @returns
 #' `TRUE` or `FALSE`, indicating if `x` is a character vector that consists of
-#' unique, syntactically valid names that do not consist of only dots or of two
-#' dots followed by a number, and do not suggest they were adjusted or
+#' unique, syntactically valid names that do **not** consist of only dots or of
+#' two dots followed by a number, and do **not** suggest they were adjusted or
 #' automatically created.
 #'
 #' @section Programming notes:
@@ -101,10 +101,8 @@
 #' [names()] to get or set object names; `janitor::make_clean_names()` to adjust
 #' names, e.g., through adjusting case and transliterating non-ASCII characters.
 #'
-#' The vignettes *Design choices regarding function input*:
-#' `vignette("design_choices", package = "checkinput")` and
-#' *Type coercion in vectors*:
-#' `vignette("type_coercion", package = "checkinput")`.
+#' The vignette *Design choices regarding function input*:
+#' `vignette("design_choices", package = "checkinput")`.
 #'
 #' @family
 #' collections of checks on type and length

--- a/R/is_natural.R
+++ b/R/is_natural.R
@@ -20,17 +20,16 @@
 #' If `allow_NA` is `TRUE`, `is_natural()` and `all_natural()` return `TRUE` for
 #' `NA_integer_` and `NA_real_` but not for the other [NA]s or [NaN].
 #'
-#' `is_natural()` and `all_natural()` allow for small numeric errors when
+#' `is_natural()`, `all_natural()` and `make_natural()` allow for small numeric
+#' errors when
 #' comparing numbers. Such numeric errors can arise because of rounding or
 #' representation error. As the `Note` at [`==`] warns, `x == round(x)` does
-#' **not** allow for such errors but tests exact equality. Functions from other
-#' packages with names like `integerish` frequently do **not** allow for small
-#' numeric errors but are instead intended to allow values that are stored as
-#' doubles (e.g., `3`) in addition to integer-type values (e.g., `3L`).
+#' **not** allow for such errors but tests exact equality.
 #'
 #' @returns `is_natural()` and `all_natural()`: `TRUE` or `FALSE` indicating if
 #' `x` is a vector of the appropriate length with only natural numbers.
-#' `make_natural()`: `x`, [rounded][round] and coerced to [integer].
+#' `make_natural()`: `x`, [rounded to a whole number][round] and coerced to
+#' [integer] type.
 #'
 #' @section Notes:
 #' `make_natural(x, all = FALSE)` and `make_natural(x, all = TRUE)` throw an
@@ -47,8 +46,8 @@
 #' or `all_natural(x)` inside [stopifnot()].
 #'
 #' [is.integer()] does **not** check that `x` is a natural number (nor if `x` is
-#' a whole number) but rather that `x` is of [type][typeof()] integer (see the
-#' `Note` in [is.integer()]).
+#' a whole number) but rather that `x` is of [type][typeof()] integer, see the
+#' `Note` in [is.integer()].
 #'
 #' @family
 #' collections of checks on type and length
@@ -164,7 +163,7 @@ all_natural <- function(x, strict = TRUE, allow_zero = FALSE, allow_NA = FALSE,
 #' @rdname is_natural
 #' @export
 make_natural <- function(x, strict = TRUE, allow_zero = FALSE, allow_NA = FALSE,
-                         all = TRUE, tol = .Machine$double.eps^0.5) {
+                         all = FALSE, tol = .Machine$double.eps^0.5) {
   name_x <- deparse1(substitute(x))
   stopifnot(is_logical(all))
   if(all && !all_natural(x = x, strict = strict, allow_zero = allow_zero,

--- a/R/is_number.R
+++ b/R/is_number.R
@@ -16,7 +16,8 @@
 #' `all_nonnegative()` and `is_nonnegative()` return `TRUE` for `0`, whereas
 #' `is_positive()` returns `FALSE` for `0`.
 #'
-#' All functions return `TRUE` for `-Inf` and `Inf` if it has the correct sign;
+#' All these functions return `TRUE` for `-Inf` and `Inf` if it has the correct
+#' sign;
 #' return `TRUE` for [NaN] (which has [mode] `numeric`, despite meaning 'not a
 #' number') if `allow_NaN` is `TRUE`; and return `FALSE` for `NA_complex_` (even
 #' if `allow_NA` is `TRUE`) because its mode is `complex` instead of `numeric`.

--- a/R/is_zerolength.R
+++ b/R/is_zerolength.R
@@ -1,10 +1,6 @@
-#' Check that x is zero-length
+#' Check that x has length zero
 #'
 #' @param x object to test.
-#'
-#' @details No check is performed on dimensions, such that a [matrix()]
-#' with zero rows is a zero-length object whereas a [data.frame()] with
-#' zero rows is **not** (see the `Examples`).
 #'
 #' @returns `TRUE` or `FALSE` indicating if `x` is a zero-length object.
 #'
@@ -15,13 +11,15 @@
 #' complex (`complex(0)`), character (`character(0)`), and list ([list()] and
 #' [data.frame()]). `""` is not a zero-length object: it has a `length` of one
 #' despite its [width][nchar()] of zero characters. A dataframe with zero rows
-#' is *not* a zero-length object: it has `length` equal to the number of columns.
+#' is **not** a zero-length object: it has `length` equal to the number of
+#' columns. In contrast, a [matrix][matrix()] with zero rows **is** a
+#' zero-length object, see the `Examples`.
 #'
 #' [is.null()] should be used to check that an object is `NULL` and, more
 #' generally, `isTRUE(all.equal(x, <zero-length object>))` should be used to
 #' check equality to a zero-length object. Testing equality should **not** be
 #' done by using [==][Comparison] because that leads to `logical(0)` if any of
-#' any sides contains a zero-length object, which gives an error when used as
+#' the sides contains a zero-length object, which gives an error when used as
 #' complete [conditional statement][Control].
 #'
 #' `all(logical(0))` returns `TRUE`, see the `Note` in [all()]. This is also the
@@ -29,8 +27,9 @@
 #' `logical`.
 #'
 #' Although zero-length objects are discarded when combined into a vector with
-#' other values, their types are taken into account for type coercion, see the
-#' vignette mentioned in the `See also` section. For example,
+#' other values, their types **are** taken into account for type coercion, see
+#' the vignette *Type coercion in vectors*:
+#' `vignette("type_coercion", package = "checkinput")`. For example,
 #' numeric `314` will be coerced to character `"314"` when it is combined into a
 #' vector with zero-length `character(0)`, such that `c(314, character(0))`
 #' results in the character string `"314"`, not in the numeric value `314`. If

--- a/R/paste_quoted.R
+++ b/R/paste_quoted.R
@@ -1,6 +1,6 @@
-#' Quote and concatenate elements to a string.
+#' Quote and concatenate x to a string
 #'
-#' Quote elements of a vector or a factor and concatenate them to a single
+#' Quote a factor or elements of a vector and concatenate the result to a single
 #' string.
 #'
 #' @details
@@ -9,11 +9,12 @@
 #' `NA`s as `"'NA_<class>_'"` (e.g., `"'NA_real_'"`; for [factors][factor] this
 #' is `"'NA_character_'"`).
 #'
-#' @param x Vector or factor to be converted to a character string.
+#' @param x Factor or vector to be converted to a character string.
 #'
 #' @returns
 #' A character string consisting of the elements of `x` surrounded by single
-#' quotes, separated by commas. See `Details` on handling of some special values.
+#' quotes, separated by commas. See `Details` on the handling of some special
+#' values.
 #'
 #' @section Notes:
 #' An error occurs if multiple arguments are provided because then `x` probably

--- a/README.Rmd
+++ b/README.Rmd
@@ -35,8 +35,8 @@ functions.
 You can visit the
 [checkinput website](https://jessealderliesten.github.io/checkinput/) to explore
 the package. To use `checkinput`, you have to install it from
-[GitHub](https://github.com/JesseAlderliesten/checkinput) using the following
-code in R (you need to run R as administrator):
+[GitHub](https://github.com/JesseAlderliesten/checkinput) using the following R
+code (you need to run R as administrator):
 
 ```{r, eval = FALSE}
 if(!requireNamespace("remotes", quietly = TRUE)) {
@@ -72,15 +72,18 @@ single non-negative number; (3) `hobbies` contains at least one character string
 and does not contain any empty strings or `NA`s.
 
 The base R equivalent of `list_hobbies()` would require much more code to check
-the input:
+the input, increasing the chance of coding errors and making it more difficult
+to read:
 
 ```{r}
 list_hobbies_base <- function(name, age, hobbies) {
-  stopifnot(is.null(dim(name)), length(name) > 0L, length(name) < 2L,
-            is.character(name), is.numeric(age), length(age) == 1L,
-            is.null(dim(age)), age >= age, is.null(dim(hobbies)),
-            length(hobbies) > 0L, is.character(hobbies),
-            all(nzchar(hobbies, keepNA = FALSE)), !anyNA(hobbies))
+  stopifnot(is.character(name), is.atomic(name), is.null(dim(name)),
+            length(name) == 1L,
+            is.numeric(age), is.atomic(age), is.null(dim(age)), length(age) == 1L,
+            nzchar(x = age, keepNA = FALSE), !is.na(age), age >= 0L,
+            is.character(hobbies), is.atomic(hobbies), is.null(dim(hobbies)),
+            length(hobbies) > 0L, all(nzchar(hobbies, keepNA = FALSE)),
+            !anyNA(hobbies))
   list(name = name, age = age, hobbies = hobbies)
 }
 ```
@@ -109,13 +112,6 @@ try(list_hobbies_base(name = "John", age = 25, hobbies = c(hobbies_John, "")))
 try(list_hobbies(name = "", age = -1, hobbies = hobbies_baby))
 try(list_hobbies_base(name = "", age = -1, hobbies = hobbies_baby))
 ```
-
-In the last example, `list_hobbies_base()` does not throw an error if a negative
-value is entered for the baby's age: the check that `age` should be non-negative
-was accidentally written as `age >= age` instead of `age >= 0`. This shows
-another advantage of specifying constraints on the input through arguments of
-the check functions instead of spelling out each condition: the reduced need to
-adjust variable names reduces the chance of coding errors.
 
 ### Design choices
 The `is_<func>(x, ...)` and `all_<func>(x, ...)` functions of `checkinput`

--- a/README.Rmd
+++ b/README.Rmd
@@ -20,17 +20,6 @@ knitr::opts_chunk$set(
 With `checkinput`, you can write concise but flexible checks for input to R
 functions.
 
-## Folder structure
-```
-├── .github
-│   └── workflows: workflows to run tests with GitHub Actions
-├── R: functions
-├── inst
-│   └── tinytest: tests
-├── man: help-files
-└── tests: setup to use 'tinytest' for testing
-```
-
 ## Installation
 You can visit the
 [checkinput website](https://jessealderliesten.github.io/checkinput/) to explore

--- a/README.md
+++ b/README.md
@@ -10,16 +10,6 @@
 With `checkinput`, you can write concise but flexible checks for input
 to R functions.
 
-## Folder structure
-
-    ├── .github
-    │   └── workflows: workflows to run tests with GitHub Actions
-    ├── R: functions
-    ├── inst
-    │   └── tinytest: tests
-    ├── man: help-files
-    └── tests: setup to use 'tinytest' for testing
-
 ## Installation
 
 You can visit the [checkinput

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You can visit the [checkinput
 website](https://jessealderliesten.github.io/checkinput/) to explore the
 package. To use `checkinput`, you have to install it from
 [GitHub](https://github.com/JesseAlderliesten/checkinput) using the
-following code in R (you need to run R as administrator):
+following R code (you need to run R as administrator):
 
 ``` r
 if(!requireNamespace("remotes", quietly = TRUE)) {
@@ -63,15 +63,18 @@ contains a single non-negative number; (3) `hobbies` contains at least
 one character string and does not contain any empty strings or `NA`s.
 
 The base R equivalent of `list_hobbies()` would require much more code
-to check the input:
+to check the input, increasing the chance of coding errors and making it
+more difficult to read:
 
 ``` r
 list_hobbies_base <- function(name, age, hobbies) {
-  stopifnot(is.null(dim(name)), length(name) > 0L, length(name) < 2L,
-            is.character(name), is.numeric(age), length(age) == 1L,
-            is.null(dim(age)), age >= age, is.null(dim(hobbies)),
-            length(hobbies) > 0L, is.character(hobbies),
-            all(nzchar(hobbies, keepNA = FALSE)), !anyNA(hobbies))
+  stopifnot(is.character(name), is.atomic(name), is.null(dim(name)),
+            length(name) == 1L,
+            is.numeric(age), is.atomic(age), is.null(dim(age)), length(age) == 1L,
+            nzchar(x = age, keepNA = FALSE), !is.na(age), age >= 0L,
+            is.character(hobbies), is.atomic(hobbies), is.null(dim(hobbies)),
+            length(hobbies) > 0L, all(nzchar(hobbies, keepNA = FALSE)),
+            !anyNA(hobbies))
   list(name = name, age = age, hobbies = hobbies)
 }
 ```
@@ -108,23 +111,9 @@ try(list_hobbies(name = "", age = -1, hobbies = hobbies_baby))
 #> Error in list_hobbies(name = "", age = -1, hobbies = hobbies_baby) : 
 #>   is_nonnegative(age) is not TRUE
 try(list_hobbies_base(name = "", age = -1, hobbies = hobbies_baby))
-#> $name
-#> [1] ""
-#> 
-#> $age
-#> [1] -1
-#> 
-#> $hobbies
-#> [1] "drinking milk"
+#> Error in list_hobbies_base(name = "", age = -1, hobbies = hobbies_baby) : 
+#>   age >= 0L is not TRUE
 ```
-
-In the last example, `list_hobbies_base()` does not throw an error if a
-negative value is entered for the baby’s age: the check that `age`
-should be non-negative was accidentally written as `age >= age` instead
-of `age >= 0`. This shows another advantage of specifying constraints on
-the input through arguments of the check functions instead of spelling
-out each condition: the reduced need to adjust variable names reduces
-the chance of coding errors.
 
 ### Design choices
 

--- a/inst/tinytest/test_is_natural.R
+++ b/inst/tinytest/test_is_natural.R
@@ -59,9 +59,9 @@ expect_false(is_natural(x = 0, strict = TRUE))
 expect_true(is_natural(x = 0, strict = FALSE))
 expect_false(is_natural(x = 0L, strict = TRUE))
 expect_error(make_natural(x = 0L, strict = TRUE),
-             pattern = "all_natural(0L) is not TRUE", fixed = TRUE)
+             pattern = "is_natural(0L) is not TRUE", fixed = TRUE)
 expect_error(make_natural(x = 1e-10, strict = TRUE),
-             pattern = "all_natural(1e-10) is not TRUE", fixed = TRUE)
+             pattern = "is_natural(1e-10) is not TRUE", fixed = TRUE)
 expect_identical(make_natural(x = 0L, strict = FALSE), 0L)
 expect_identical(make_natural(x = 1e-10, strict = FALSE), 0L)
 expect_true(is_natural(x = 0L, strict = FALSE))
@@ -121,7 +121,7 @@ expect_warning(
   pattern = "NAs produced by integer overflow", strict = TRUE, fixed = TRUE)
 expect_warning(
   expect_error(make_natural(x = .Machine$integer.max + 1L),
-               pattern = "all_natural(.Machine$integer.max + 1L) is not TRUE",
+               pattern = "is_natural(.Machine$integer.max + 1L) is not TRUE",
                fixed = TRUE),
   pattern = "NAs produced by integer overflow", strict = TRUE, fixed = TRUE)
 
@@ -130,7 +130,7 @@ expect_warning(
   pattern = "NAs produced by integer overflow", strict = TRUE, fixed = TRUE)
 expect_warning(
   expect_error(make_natural(x = (-1L * .Machine$integer.max) - 1L),
-               pattern = "all_natural((-1L * .Machine$integer.max) - 1L) is not TRUE",
+               pattern = "is_natural((-1L * .Machine$integer.max) - 1L) is not TRUE",
                fixed = TRUE),
   pattern = "NAs produced by integer overflow", strict = TRUE, fixed = TRUE)
 

--- a/inst/tinytest/test_is_natural.R
+++ b/inst/tinytest/test_is_natural.R
@@ -73,11 +73,6 @@ expect_false(is_natural(x = numeric(0), allow_zero = FALSE, strict = FALSE))
 expect_true(is_natural(x = numeric(0), allow_zero = TRUE, strict = FALSE))
 expect_false(is_natural(x = NULL, allow_zero = TRUE, strict = FALSE))
 
-# Testing a value that cannot be represented as integer by R (R uses 32-bit
-# integers, see 'Details' in help(`integer`)). Negative values are not natural
-# anyway, so no need to test large negative numbers.
-expect_false(is_natural(x = .Machine$integer.max + 1))
-
 expect_false(is_natural(x = c(3, 5 + 1e-10, 5.0, 1e4, 1.2e4)))
 expect_error(make_natural(x = c(3, 5 + 1e-10, 5.0, 1e4, 1.2e4), all = FALSE),
              pattern = "is_natural(c(3, 5 + 1e-10, 5, 10000, 12000)) is not TRUE",
@@ -117,13 +112,27 @@ expect_false(all_natural(x = numeric(0), allow_zero = FALSE, strict = FALSE))
 expect_true(all_natural(x = numeric(0), allow_zero = TRUE, strict = FALSE))
 expect_false(all_natural(x = NULL, allow_zero = TRUE, strict = FALSE))
 
-# Testing a value that cannot be represented as integer by R (R uses 32-bit
-# integers, see 'Details' in help(`integer`)). Negative values are not natural
-# anyway, so no need to test large negative numbers.
-expect_false(all_natural(x = .Machine$integer.max + 1))
-expect_error(make_natural(x = .Machine$integer.max + 1),
-             pattern = "all_natural(.Machine$integer.max + 1) is not TRUE",
-             fixed = TRUE)
+# Testing values that cannot be represented as integer by R (R uses 32-bit
+# integers, see section 'Details' in help("integer")). Although negative values
+# are clearly not natural numbers, they will be converted to NA_integer_ so it
+# is worthwile to test them as well.
+expect_warning(
+  expect_false(all_natural(x = .Machine$integer.max + 1L)),
+  pattern = "NAs produced by integer overflow", strict = TRUE, fixed = TRUE)
+expect_warning(
+  expect_error(make_natural(x = .Machine$integer.max + 1L),
+               pattern = "all_natural(.Machine$integer.max + 1L) is not TRUE",
+               fixed = TRUE),
+  pattern = "NAs produced by integer overflow", strict = TRUE, fixed = TRUE)
+
+expect_warning(
+  expect_false(all_natural(x = (-1L * .Machine$integer.max) - 1L)),
+  pattern = "NAs produced by integer overflow", strict = TRUE, fixed = TRUE)
+expect_warning(
+  expect_error(make_natural(x = (-1L * .Machine$integer.max) - 1L),
+               pattern = "all_natural((-1L * .Machine$integer.max) - 1L) is not TRUE",
+               fixed = TRUE),
+  pattern = "NAs produced by integer overflow", strict = TRUE, fixed = TRUE)
 
 expect_true(all_natural(x = c(3, 5 + 1e-10, 5.0, 1e4, 1.2e4)))
 expect_identical(make_natural(x = c(3, 5 + 1e-10, 5.0, 1e4, 1.2e4), all = TRUE),

--- a/man/all_names.Rd
+++ b/man/all_names.Rd
@@ -13,8 +13,8 @@ all_names(x, allow_underscores = TRUE)
 }
 \value{
 \code{TRUE} or \code{FALSE}, indicating if \code{x} is a character vector that consists of
-unique, syntactically valid names that do not consist of only dots or of two
-dots followed by a number, and do not suggest they were adjusted or
+unique, syntactically valid names that do \strong{not} consist of only dots or of
+two dots followed by a number, and do \strong{not} suggest they were adjusted or
 automatically created.
 }
 \description{
@@ -43,7 +43,7 @@ listed as \link{reserved} words even though they are not recognised as
 syntactically invalid by \code{\link[=make.names]{make.names()}}.
 
 Suspicious names are not allowed by \code{all_names()}. A suspicious name contains
-a pattern that suggests it originally was syntactically invalid and has been
+a pattern suggesting it originally was syntactically invalid and has been
 \strong{adjusted} into a syntactically valid name, or has been adjusted to make names
 \link[=make.unique]{unique}. Such adjustments usually occur silently, for example
 when data is read into \R, which is problematic because it cannot reliably be
@@ -62,8 +62,8 @@ throughout the \href{https://tidyverse.org/}{tidyverse}:
 letter, number, dot or underscore): \code{make.names()} and
 \code{vctrs::vec_as_names(x, repair = "universal")} replace such characters with
 a dot. Their identification is based on the assumption that names
-originally did \strong{not} contain dots, which is good practice (unfortunately
-not strictly followed in base-\R, e.g., in \code{\link[=data.frame]{data.frame()}}) preventing names
+originally did \strong{not} contain dots, which is good practice (despite not
+being strictly followed in base-\R, e.g., in \code{\link[=data.frame]{data.frame()}}) preventing names
 containing a dot from being confused with \link[=UseMethod]{methods} used on
 \link[=is.object]{classed objects}.
 \item adjustments to make duplicated names unique: \code{make.names(x, unique = TRUE)}
@@ -78,15 +78,15 @@ names is present, e.g., \code{a.2} will be flagged as suspicious even if \code{a
 not followed by a number, syntactically valid: \code{make.names()} prepends \code{X};
 \code{vctrs::vec_as_names(x, repair = "universal")} prepends one or more dots.
 \item adjustments to name unnamed columns: \code{data.frame()} uses pattern \code{V1},
-\code{V2}, \code{V3} if a matrix without column names is converted to a data.frame,
+\code{V2}, \code{V3} if a matrix without column names is converted to a data frame,
 and \code{read.csv(..., header = FALSE)} uses the same pattern for data without
 column names; \code{read.csv(..., header = TRUE)} uses pattern \code{X}, \code{X.1}, \code{X.2}.
 }
 
 Names containing underscores (\verb{_}) are by default \strong{allowed} by \code{all_names()}
 because names containing underscores are not syntactically invalid. However,
-setting \code{allow_underscores} to \code{FALSE} to not allow such names is useful to
-check that names do not contain underscores, for example if several names
+setting \code{allow_underscores} to \code{FALSE} to \strong{not} allow such names is useful
+to check that names do not contain underscores, for example if several names
 will be concatenated to create an ID-tag, separating the parts by underscores.
 }
 \section{Programming notes}{
@@ -142,10 +142,8 @@ on the syntactical validity of names.
 \code{\link[=names]{names()}} to get or set object names; \code{janitor::make_clean_names()} to adjust
 names, e.g., through adjusting case and transliterating non-ASCII characters.
 
-The vignettes \emph{Design choices regarding function input}:
-\code{vignette("design_choices", package = "checkinput")} and
-\emph{Type coercion in vectors}:
-\code{vignette("type_coercion", package = "checkinput")}.
+The vignette \emph{Design choices regarding function input}:
+\code{vignette("design_choices", package = "checkinput")}.
 
 Other collections of checks on type and length:
 \code{\link[=all_characters]{all_characters()}},

--- a/man/is_natural.Rd
+++ b/man/is_natural.Rd
@@ -27,7 +27,7 @@ make_natural(
   strict = TRUE,
   allow_zero = FALSE,
   allow_NA = FALSE,
-  all = TRUE,
+  all = FALSE,
   tol = .Machine$double.eps^0.5
 )
 }
@@ -48,7 +48,8 @@ than \code{tol} are considered equal.}
 \value{
 \code{is_natural()} and \code{all_natural()}: \code{TRUE} or \code{FALSE} indicating if
 \code{x} is a vector of the appropriate length with only natural numbers.
-\code{make_natural()}: \code{x}, \link[=round]{rounded} and coerced to \link{integer}.
+\code{make_natural()}: \code{x}, \link[=round]{rounded to a whole number} and coerced to
+\link{integer} type.
 }
 \description{
 Test element-wise near-equality to natural numbers while allowing for small
@@ -65,13 +66,11 @@ numbers in this implementation.
 If \code{allow_NA} is \code{TRUE}, \code{is_natural()} and \code{all_natural()} return \code{TRUE} for
 \code{NA_integer_} and \code{NA_real_} but not for the other \link{NA}s or \link{NaN}.
 
-\code{is_natural()} and \code{all_natural()} allow for small numeric errors when
+\code{is_natural()}, \code{all_natural()} and \code{make_natural()} allow for small numeric
+errors when
 comparing numbers. Such numeric errors can arise because of rounding or
 representation error. As the \code{Note} at \code{\link{==}} warns, \code{x == round(x)} does
-\strong{not} allow for such errors but tests exact equality. Functions from other
-packages with names like \code{integerish} frequently do \strong{not} allow for small
-numeric errors but are instead intended to allow values that are stored as
-doubles (e.g., \code{3}) in addition to integer-type values (e.g., \code{3L}).
+\strong{not} allow for such errors but tests exact equality.
 }
 \section{Notes}{
 
@@ -91,8 +90,8 @@ assign the result of \code{make_natural(x)} to \code{x} without using \code{is_n
 or \code{all_natural(x)} inside \code{\link[=stopifnot]{stopifnot()}}.
 
 \code{\link[=is.integer]{is.integer()}} does \strong{not} check that \code{x} is a natural number (nor if \code{x} is
-a whole number) but rather that \code{x} is of \link[=typeof]{type} integer (see the
-\code{Note} in \code{\link[=is.integer]{is.integer()}}).
+a whole number) but rather that \code{x} is of \link[=typeof]{type} integer, see the
+\code{Note} in \code{\link[=is.integer]{is.integer()}}.
 }
 
 \examples{

--- a/man/is_number.Rd
+++ b/man/is_number.Rd
@@ -44,7 +44,8 @@ is also allowed for both types of functions.
 \code{all_nonnegative()} and \code{is_nonnegative()} return \code{TRUE} for \code{0}, whereas
 \code{is_positive()} returns \code{FALSE} for \code{0}.
 
-All functions return \code{TRUE} for \code{-Inf} and \code{Inf} if it has the correct sign;
+All these functions return \code{TRUE} for \code{-Inf} and \code{Inf} if it has the correct
+sign;
 return \code{TRUE} for \link{NaN} (which has \link{mode} \code{numeric}, despite meaning 'not a
 number') if \code{allow_NaN} is \code{TRUE}; and return \code{FALSE} for \code{NA_complex_} (even
 if \code{allow_NA} is \code{TRUE}) because its mode is \code{complex} instead of \code{numeric}.

--- a/man/is_zerolength.Rd
+++ b/man/is_zerolength.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/is_zerolength.R
 \name{is_zerolength}
 \alias{is_zerolength}
-\title{Check that x is zero-length}
+\title{Check that x has length zero}
 \usage{
 is_zerolength(x)
 }
@@ -13,12 +13,7 @@ is_zerolength(x)
 \code{TRUE} or \code{FALSE} indicating if \code{x} is a zero-length object.
 }
 \description{
-Check that x is zero-length
-}
-\details{
-No check is performed on dimensions, such that a \code{\link[=matrix]{matrix()}}
-with zero rows is a zero-length object whereas a \code{\link[=data.frame]{data.frame()}} with
-zero rows is \strong{not} (see the \code{Examples}).
+Check that x has length zero
 }
 \section{Notes}{
 
@@ -28,13 +23,15 @@ logical (\code{logical(0)}), integer (\code{integer(0)}), double (\code{numeric(
 complex (\code{complex(0)}), character (\code{character(0)}), and list (\code{\link[=list]{list()}} and
 \code{\link[=data.frame]{data.frame()}}). \code{""} is not a zero-length object: it has a \code{length} of one
 despite its \link[=nchar]{width} of zero characters. A dataframe with zero rows
-is \emph{not} a zero-length object: it has \code{length} equal to the number of columns.
+is \strong{not} a zero-length object: it has \code{length} equal to the number of
+columns. In contrast, a \link{matrix} with zero rows \strong{is} a
+zero-length object, see the \code{Examples}.
 
 \code{\link[=is.null]{is.null()}} should be used to check that an object is \code{NULL} and, more
 generally, \verb{isTRUE(all.equal(x, <zero-length object>))} should be used to
 check equality to a zero-length object. Testing equality should \strong{not} be
 done by using \link[=Comparison]{==} because that leads to \code{logical(0)} if any of
-any sides contains a zero-length object, which gives an error when used as
+the sides contains a zero-length object, which gives an error when used as
 complete \link[=Control]{conditional statement}.
 
 \code{all(logical(0))} returns \code{TRUE}, see the \code{Note} in \code{\link[=all]{all()}}. This is also the
@@ -42,8 +39,9 @@ case for \code{all(numeric(0))} and \code{all(character(0))} that get coerced to
 \code{logical}.
 
 Although zero-length objects are discarded when combined into a vector with
-other values, their types are taken into account for type coercion, see the
-vignette mentioned in the \verb{See also} section. For example,
+other values, their types \strong{are} taken into account for type coercion, see
+the vignette \emph{Type coercion in vectors}:
+\code{vignette("type_coercion", package = "checkinput")}. For example,
 numeric \code{314} will be coerced to character \code{"314"} when it is combined into a
 vector with zero-length \code{character(0)}, such that \code{c(314, character(0))}
 results in the character string \code{"314"}, not in the numeric value \code{314}. If

--- a/man/paste_quoted.Rd
+++ b/man/paste_quoted.Rd
@@ -2,19 +2,20 @@
 % Please edit documentation in R/paste_quoted.R
 \name{paste_quoted}
 \alias{paste_quoted}
-\title{Quote and concatenate elements to a string.}
+\title{Quote and concatenate x to a string}
 \usage{
 paste_quoted(x)
 }
 \arguments{
-\item{x}{Vector or factor to be converted to a character string.}
+\item{x}{Factor or vector to be converted to a character string.}
 }
 \value{
 A character string consisting of the elements of \code{x} surrounded by single
-quotes, separated by commas. See \code{Details} on handling of some special values.
+quotes, separated by commas. See \code{Details} on the handling of some special
+values.
 }
 \description{
-Quote elements of a vector or a factor and concatenate them to a single
+Quote a factor or elements of a vector and concatenate the result to a single
 string.
 }
 \details{

--- a/vignettes/design_choices.Rmd
+++ b/vignettes/design_choices.Rmd
@@ -39,16 +39,16 @@ than `x`, e.g., when values other than `TRUE` or `FALSE` are used for `allow_NA`
 
 The default arguments make functions of `checkinput` more restrictive than the
 equivalent functions in base R (e.g., `checkinput::is_logical()` versus
-`base::is.logical()`), reflecting that the functions of `checkinput` are
-intended for argument checking, where, for example, zero-length `x` is unwanted.
+`base::is.logical()`) because the functions of `checkinput` are intended for
+argument checking where, for example, zero-length `x` is unwanted.
 
 ## Length of x
 By default, `is_<func>(x)` only returns `TRUE` for `x` of length one (with the
 obvious exception of `is_zerolength(x)`) and `all_<func>(x)` only returns `TRUE`
 for `x` of length larger than zero. Set argument `allow_zero` to `TRUE` to also
-return `TRUE` for zero-length `x` of the correct type. See `is_zerolength()` and
-`vignette("type_coercion", package = "checkinput")` for a discussion of some
-issues with zero-length input.
+return `TRUE` for zero-length `x` of the correct type. See
+`help("Is_zerolength")` and `vignette("type_coercion", package = "checkinput")`
+for a discussion of some issues with zero-length input.
 
 ## NAs in x
 By default, functions only return `TRUE` for `x` without `NA`s. Set argument

--- a/vignettes/type_coercion.Rmd
+++ b/vignettes/type_coercion.Rmd
@@ -26,11 +26,12 @@ that objects are converted ('coerced') to a common type when combined in a
 vector. The type of the vector, and thus of all its components, will be the
 highest type of the components in the hierarchy `NULL` < `raw` < `logical` <
 `integer` < `double` < `complex` < `character` < `list` < `expression`, see the
-section `Details` in `help("c")` and `help("typeof")`. For example, numeric
+section `Details` in `help("c")` and the section `Value` in `help("typeof")`.
+For example, numeric
 `314` will be coerced to character `"314"` when it is combined in a vector with
 character `"nco"`, such that `c(314, "nco")` results in the character vector
 `c("314", "nco")`. This also holds for the logical `NA`, which will be coerced
-to `NA_character_`, which also prints as `NA`.
+to `NA_character_`, even though it is also printed as `NA`.
 
 ```{r Type coercion}
 num <- 314
@@ -90,7 +91,8 @@ all(unlist(lapply(X = z, FUN = all_characters)))
 
 
 ## Zero-length values
-Although zero-length objects (see `is_zerolength()`) are discarded when combined
+Although zero-length objects (see `help("Is_zerolength")`) are discarded when
+combined
 into a vector with other values, their types are taken into account for type
 coercion. For example, numeric `314` will be coerced to character `"314"` when
 it is combined into a vector with zero-length `character(0)`, such that


### PR DESCRIPTION
### Breaking changes
- `make_natural()`: change default `all` from `TRUE` to `FALSE` because it will be used more often with scalar input.