### PR TITLE
`is_path()`: adjusted to warn and return `FALSE` if `path` is not a valid path.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,8 +4,9 @@
 - Added dependency `fs` that is used in `is_path()`.
 
 ### Added functions
-- `is_path()`: moved from package `progutils` to `checkinput`. Adjusted to warn
-  and return `FALSE` instead of throwing an error if `path` is not a valid path.
+- `is_path()`: move from package `progutils` to `checkinput`. Warn and return
+  `FALSE` instead of throwing an error if `path` is not a valid path. Not warn
+  about duplicated file separators. Not allow filenames to start with a hyphen.
 
 
 # checkinput 0.8.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,8 @@
 - Added dependency `fs` that is used in `is_path()`.
 
 ### Added functions
-- `is_path()`: moved from package `progutils` to `checkinput`.
+- `is_path()`: moved from package `progutils` to `checkinput`. Adjusted to warn
+  and return `FALSE` instead of throwing an error if `path` is not a valid path.
 
 
 # checkinput 0.8.0

--- a/R/is_path.R
+++ b/R/is_path.R
@@ -1,76 +1,89 @@
 #' Check that `x` is a valid path
 #'
-#' Check that `x` is a path that is likely to be valid.
+#' Check that `x` is a valid path, possibly containing a valid filename.
 #'
-#' @param path [character string][is_character()] with the path.
+#' @param path [character string][is_character()] with the path, possibly
+#' containing a valid filename.
 #'
 #' @details
-#' `is_path()` puts restrictions on paths so it can be used to check for
-#' valid paths before creating a directory or a file:
+#' `is_path()` is intended to be used to check for valid paths before creating a
+#' directory or a file. Therefore it imposes the following restrictions:
 #'
 #' - `path` should **not** contain the characters `"`, `*`, `?`, `|`, `<`, `>`,
 #'   nor any of the control characters (`ASCII` octal codes 000 through 037 and
 #'   177, see `help("regex")`).
-#' - `path` should **not** contain repeated file separators (e.g., `//` or
-#'   `\\\\`).
 #' - `path` components (i.e., parts separated by file separators `/` or `\\`)
 #'   should **not** be the Windows-reserved terms `CON`, `PRN`, `AUX`, `NUL`,
 #'   `COM<non-zero digit>`, `LPT<non-zero digit>`, case-insensitive variants of
 #'   these names, or these names followed by an extension.
-#' - `path` components
-#'   should **not** end with a space or dot (`"."` and `".."` are allowed as
-#'   first component to indicate the working directory and the parent directory,
-#'   respectively).
+#' - `path` components should **not** end with a space.
+#' - `path` components should **not** end with a dot, with the exception of
+#'   `"."` and `".."` that are allowed as first component to indicate the
+#'   working directory and the parent directory, respectively.
 #' - `path` should not point to `tempdir()`: a temporary subdirectory should be
 #'   used instead (see `progutils::create_tempdir()`).
+#' - If `path` contains a file extension (or compression extension, the current
+#'   implementation does not distinguish those from each other), the part after
+#'   the last slash is considered the filename, which **should** adhere to the
+#'   restrictions listed above, and in addition should **not** contain `:`
+#'   **nor** start with a space or a hyphen (`-`), while it **might** contain
+#'   the Windows-reserved terms given in the second point above.
 #'
-#' Furthermore, if `path` contains a file extension or compression extension,
-#' the part after the last
-#' slash is considered the filename, which should adhere to the same
-#' restrictions as the path but should **not** contain `:` **nor**
-#' start with a space, while it might contain Windows-reserved terms.
+#' These restrictions `path` consider characters and words that are not allowed
+#' in Windows and thus would lead to an error when used to create a directory or
+#' file; and characters that are silently removed in Windows and thus would lead
+#' to a mismatch between the created directory and the returned path when used
+#' to create a directory.
 #'
-#' These restrictions on the path and the filename consider characters that
-#' would lead to an error in Windows because they are not allowed; characters
-#' that would lead to a mismatch between the created directory and the returned
-#' path because they are silently removed in Windows; and words that are
-#' reserved names in Windows.
+#' `is_path()` allows some patterns that will not occur in real (i.e., existing)
+#' paths or filenames:
 #'
-#' `path` does **not** have to point to an existing directory: `path` even does
-#' **not** have to contain a file separator (e.g., `/` or `\\`), such that
-#' `is_path()` can be used to check that input to [fs::path()] only contains
-#' allowed characters.
-#'
+#' - `path` does **not** have to contain a file separator (i.e., `/` or `\\`).
+#'   This makes it possible to use `is_path()` to check that input to
+#'   [fs::path()] only contains allowed characters.
+#' - `path` does **not** have to point to an existing directory (see the
+#'   previous point).
+#' - `path` might contain repeated file separators (e.g., `//` or `\\\\`): these
+#'   will be treated as if they were only a single file separator.
+#' - `path` might contain trailing file separators, even though these might be
+#'   ignored or removed in some operations (e.g., they are removed by [file.path()]
+#'   and [fs::path()])
+#'   .
 #' @returns
 #' `TRUE` or `FALSE` indicating if `path` is a valid path, possibly containing a
 #' valid filename.
 #'
 #' @section Programming notes:
-#' On MacOS, the output of `tempdir()` is preceded by duplicated forward slashes
-#' in R cmd checks (e.g., `/var/[...]/T//RtmpxC2Fyl/working_dir/RtmpdnqgUR`),
-#' leading to a spurious warning from `is_path()`.
-#'
 #' The file separator is a backslash (`\`) on Windows but a forward slash (`/`)
 #' on other operating systems ([.Platform$file.sep][.Platform] gives the file
 #' separator used on the current platform). Furthermore, the backslash is used
 #' as [escape character][regex] in \R, such that backslashes need to be escaped
-#' in \R code. Thus, to warn if a [string][is_character()] contains
-#' a file separator, one should write the warning message as
-#' `warning("Repeated '/' or '\\'")` which will be printed as
-#' `Repeated '/' or '\'`. Checks on the presence of slashes and backslashes
-#' should use `grepl(pattern = "/", x = string)` and
-#' `grepl(pattern = "\\\\", x = string)`. This makes it cumbersome to get the
-#' correct type and number of slashes to compare with the path recorded in a
-#' warning message, such that it is more robust to check only for fixed parts of
-#' the message (e.g., `"Repeated"`), possibly followed by a check like
+#' in \R code. Thus, a check on the presence of repeated slashes and backslashes
+#' in [string][is_character()] `string` would use
+#' `grepl(pattern = "//", x = string, fixed = TRUE)` and
+#' `grepl(pattern = "\\\\", x = string, fixed = TRUE)`. The message to point out
+#' their presence would be written as `message("Repeated '/' or '\\'")` which
+#' would be printed as `Repeated '/' or '\'`. This makes it cumbersome to get
+#' the correct type and number of slashes to compare with the path recorded in a
+#' message, such that it is more robust to check only for fixed parts of the
+#' message (e.g., `"Repeated"`), possibly followed by a check like
 #' `tinytest::expect_true(dir.exists(string))`.
 #'
-#' Trailing slashes or backslashes are allowed, even though these might be
-#' removed in some operations.
+#' On MacOS, the output of `tempdir()` is preceded by duplicated forward slashes
+#' (e.g., `/var/[...]/T//RtmpxC2Fyl/working_dir/RtmpdnqgUR`) which led to
+#' spurious warnings in earlier versions of `is_path()` that warned about
+#' duplicated file separators.
 #'
 #' @section References:
 #' - Naming files, paths, and namespaces from
 #'   [Microsoft](https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file)
+#' - Entries
+#'   [Filename](https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap03.html#tag_03_146),
+#'   [Portable filenames](https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap03.html#tag_03_264)
+#'   and
+#'   [Pathname](https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap03.html#tag_03_254)
+#'   from the Posix standard
+#'   [POSIX.1-2024](https://pubs.opengroup.org/onlinepubs/9799919799/)
 #' - Comparison of file systems from
 #'   [Wikipedia](https://en.wikipedia.org/wiki/Comparison_of_file_systems#Limits)
 #'
@@ -119,14 +132,6 @@ is_path <- function(path) {
     path_comp <- unlist(strsplit(x = path_comp, split = "\\", fixed = TRUE))
   }
 
-  # The check for zero-character (i.e., "") is needed to catch patterns like "/\\"
-  if(any(!nzchar(path_comp)) || grepl(pattern = "//", x = path, fixed = TRUE) ||
-     grepl(pattern = "\\\\", x = path, fixed = TRUE)) {
-    path_ok <- FALSE
-    warning(paste_quoted(deparse(substitute(path))),
-            "should not contain repeated '/' or '\\\\':\n", path)
-  }
-
   if(grepl(pattern = '["*?|<>]', x = path)) {
     path_ok <- FALSE
     warning(paste_quoted(deparse(substitute(path))),
@@ -165,10 +170,10 @@ is_path <- function(path) {
   file_ext <- fs::path_ext(path = filename)
   filename_no_ext <- fs::path_ext_remove(path = filename)
 
-  # To catch case where filename ends in a dot, e.g., "ff..txt"
   end_dot <- filename != "." && filename != ".." &&
     (endsWith(filename_no_ext, suffix = ".") ||
-       # Modified from fs::path_ext_remove() to only remove a single dot
+       # To catch case where filename ends in a dot, e.g., "ff..txt": modified
+       # from fs::path_ext_remove() to only remove a single dot
        endsWith(sub("\\.([^.]+)$", "", filename, perl = TRUE), suffix = "."))
 
   if(!end_dot && (length(file_ext) == 0L || !nzchar(file_ext))) {
@@ -186,9 +191,11 @@ is_path <- function(path) {
               ") should not be empty:\n", path)
     }
 
-    if(startsWith(x = filename, prefix = " ")) {
+    if(startsWith(x = filename, prefix = " ") ||
+       startsWith(x = filename, prefix = "-")) {
       path_ok <- FALSE
-      warning("'filename' should not start with ' ' (i.e., a space):\n", filename)
+      warning("'filename' should not start with ' ' (i.e., a space) or '-':\n",
+              filename)
     }
 
     if(grepl(pattern = ":", x = filename, fixed = TRUE)) {
@@ -198,7 +205,6 @@ is_path <- function(path) {
 
     if(endsWith(x = filename_no_ext, suffix = " ") ||
        endsWith(x = filename_no_ext, suffix = ".") ||
-       # To catch case where filename ends in a dot, e.g., "ff..txt"
        end_dot) {
       path_ok <- FALSE
       warning("'filename' should not end with ' ' or '.' (i.e., a space or a",

--- a/R/is_path.R
+++ b/R/is_path.R
@@ -11,6 +11,8 @@
 #' - `path` should **not** contain the characters `"`, `*`, `?`, `|`, `<`, `>`,
 #'   nor any of the control characters (`ASCII` octal codes 000 through 037 and
 #'   177, see `help("regex")`).
+#' - `path` should **not** contain repeated file separators (e.g., `//` or
+#'   `\\\\`).
 #' - `path` components (i.e., parts separated by file separators `/` or `\\`)
 #'   should **not** be the Windows-reserved terms `CON`, `PRN`, `AUX`, `NUL`,
 #'   `COM<non-zero digit>`, `LPT<non-zero digit>`, case-insensitive variants of
@@ -37,12 +39,11 @@
 #' `path` does **not** have to point to an existing directory: `path` even does
 #' **not** have to contain a file separator (e.g., `/` or `\\`), such that
 #' `is_path()` can be used to check that input to [fs::path()] only contains
-#' allowed characters. Repeated file separators (e.g., `//` or `\\\\`) are
-#' treated as single separators, with a warning.
+#' allowed characters.
 #'
 #' @returns
-#' `TRUE`: an error occurs if `path` is not a valid path or if `path` contains a
-#' file extension but the filename is not valid.
+#' `TRUE` or `FALSE` indicating if `path` is a valid path, possibly containing a
+#' valid filename.
 #'
 #' @section Programming notes:
 #' On MacOS, the output of `tempdir()` is preceded by duplicated forward slashes
@@ -88,18 +89,22 @@
 #' @examples
 #' is_path(getwd())
 #' is_path(fs::path_wd("abcd"))
-#' try(is_path(fs::path_wd("ab|cd")))
+#' is_path(fs::path_wd("ab|cd"))
 #'
 #' is_path(fs::path_wd("abcd.txt"))
 #' is_path(fs::path_wd("abcd.txt.gz"))
 #' is_path(fs::path_wd("abcd.gz"))
 #'
-#' try(is_path(fs::path_wd("ab:cd.txt")))
-#' try(is_path(fs::path_wd("ab|cd.txt")))
+#' is_path(fs::path_wd("ab:cd.txt"))
+#' is_path(fs::path_wd("ab|cd.txt"))
 #'
 #' @export
 is_path <- function(path) {
-  stopifnot(is_character(path))
+  path_ok <- TRUE
+
+  if(!is_character(path)) {
+    path_ok <- FALSE
+  }
 
   # Notes:
   # - split = c("/", "\\") does not work because that recycles 'split' along 'x'
@@ -117,26 +122,30 @@ is_path <- function(path) {
   # The check for zero-character (i.e., "") is needed to catch patterns like "/\\"
   if(any(!nzchar(path_comp)) || grepl(pattern = "//", x = path, fixed = TRUE) ||
      grepl(pattern = "\\\\", x = path, fixed = TRUE)) {
-    warning("Repeated '/' or '\\\\' in ", paste_quoted(deparse(substitute(path))),
-            " will be ignored:\n", path)
+    path_ok <- FALSE
+    warning(paste_quoted(deparse(substitute(path))),
+            "should not contain repeated '/' or '\\\\':\n", path)
   }
 
   if(grepl(pattern = '["*?|<>]', x = path)) {
-    stop(paste_quoted(deparse(substitute(path))),
-         " should not contain '\"', '*', '?', '|', '<' or '>':\n", path)
+    path_ok <- FALSE
+    warning(paste_quoted(deparse(substitute(path))),
+            " should not contain '\"', '*', '?', '|', '<' or '>':\n", path)
   }
 
   # "[[:cntrl:]]" matches the control characters, see help("regex")
   if(grepl(pattern = "[[:cntrl:]]", x = path)) {
-    stop("'path' should not contain control characters:\n", path)
+    path_ok <- FALSE
+    warning("'path' should not contain control characters:\n", path)
   }
 
   Windows_reserved <- c("aux", paste0("com", 1:9), "con", paste0("lpt", 1:9),
                         "nul", "prn")
   if(any(Windows_reserved %in% tolower(path_comp))) {
+    path_ok <- FALSE
     reserved_comp <- path_comp[tolower(path_comp) %in% Windows_reserved]
-    stop("'path' components should not contain Windows-reserved names (",
-         paste_quoted(reserved_comp), "):\n", path)
+    warning("'path' components should not contain Windows-reserved names (",
+            paste_quoted(reserved_comp), "):\n", path)
   }
 
   bool_invalid_dot <- endsWith(x = path_comp, suffix = ".")
@@ -146,9 +155,10 @@ is_path <- function(path) {
     bool_invalid_dot[1] <- FALSE
   }
   if(any(bool_invalid_dot | endsWith(x = path_comp, suffix = " "))) {
-    stop("Path components in ", paste_quoted(deparse(substitute(path))),
-         " should not end with ' ' or '.' (i.e., a space or a dot):\n",
-         path)
+    path_ok <- FALSE
+    warning("Path components in ", paste_quoted(deparse(substitute(path))),
+            " should not end with ' ' or '.' (i.e., a space or a dot):\n",
+            path)
   }
 
   filename <- basename(path)
@@ -171,34 +181,39 @@ is_path <- function(path) {
       basename(normalizePath(tempdir(), winslash = "/", mustWork = FALSE))
 
     if(length(filename_no_ext) == 0L || !nzchar(filename_no_ext)) {
-      stop("filename without extension (", paste_quoted(filename_no_ext),
-           ") should not be empty:\n", path)
+      path_ok <- FALSE
+      warning("filename without extension (", paste_quoted(filename_no_ext),
+              ") should not be empty:\n", path)
     }
 
     if(startsWith(x = filename, prefix = " ")) {
-      stop("'filename' should not start with ' ' (i.e., a space):\n", filename)
+      path_ok <- FALSE
+      warning("'filename' should not start with ' ' (i.e., a space):\n", filename)
     }
 
     if(grepl(pattern = ":", x = filename, fixed = TRUE)) {
-      stop("'filename' should not contain ':':\n", filename)
+      path_ok <- FALSE
+      warning("'filename' should not contain ':':\n", filename)
     }
 
     if(endsWith(x = filename_no_ext, suffix = " ") ||
        endsWith(x = filename_no_ext, suffix = ".") ||
        # To catch case where filename ends in a dot, e.g., "ff..txt"
        end_dot) {
-      stop("'filename' should not end with ' ' or '.' (i.e., a space or a dot):\n",
-           filename)
+      path_ok <- FALSE
+      warning("'filename' should not end with ' ' or '.' (i.e., a space or a",
+              " dot):\n", filename)
     }
   }
 
   if(to_tempdir) {
-    stop(paste0(
+    path_ok <- FALSE
+    warning(paste0(
       "'path' should not point to 'tempdir()': instead, point to a subdirectory",
       " in\ntempdir() through 'fs::path(tempdir(), \"subdir\")', or create such",
       " a subdirectory\nthrough 'progutils::create_tempdir(subdir = \"subdir\")':\n",
       path))
   }
 
-  TRUE
+  path_ok
 }

--- a/inst/tinytest/test_is_path.R
+++ b/inst/tinytest/test_is_path.R
@@ -45,6 +45,10 @@ expect_warning(
   expect_false(is_path(path = fs::path_wd("ab:cd.txt"))),
   pattern = "'filename' should not contain ':'", fixed = TRUE)
 
+expect_warning(
+  expect_false(is_path(path = "ab:cd.txt")),
+  pattern = "'filename' should not contain ':'", fixed = TRUE)
+
 for(control_char in paste0("\005", "\025", "\035", "\177")) {
   expect_warning(
     expect_false(is_path(path = fs::path_wd(paste0("ab", control_char, "cd")))),
@@ -167,6 +171,19 @@ expect_warning(
   expect_false(is_path(path = fs::path_wd("subdir", "filename..txt"))),
   pattern = warn_space_dot, fixed = TRUE)
 
+# Filenames should not start with a space or a hyphen
+expect_silent(expect_true(is_path(path = fs::path_wd("subdir", " filename"))))
+
+expect_warning(
+  expect_false(is_path(path = fs::path_wd("subdir", " filename.txt"))),
+  pattern = "should not start with ' ' (i.e., a space) or '-'", fixed = TRUE)
+
+expect_silent(expect_true(is_path(path = fs::path_wd("subdir", "-filename"))))
+
+expect_warning(
+  expect_false(is_path(path = fs::path_wd("subdir", "-filename.txt"))),
+  pattern = "should not start with ' ' (i.e., a space) or '-'", fixed = TRUE)
+
 ##### Temporary directory #####
 expect_warning(
   expect_false(is_path(path = tempdir())),
@@ -177,17 +194,14 @@ expect_true(is_path(fs::path(tempdir(), "subdir")))
 
 ##### Repeated file separators #####
 # Need file.path() because fs::path_wd() removes repeated file separators
-expect_warning(
-  expect_false(is_path(path = file.path(fs::path_wd("subdir"), "/filename.txt"))),
-  pattern = "not contain repeated '/' or '\\\\'", fixed = TRUE, strict = TRUE)
+expect_silent(
+  expect_true(is_path(path = file.path(fs::path_wd("subdir"), "/filename.txt"))))
 
-expect_warning(
-  expect_false(is_path(path = file.path(fs::path_wd("subdir"), "\\filename.txt"))),
-  pattern = "not contain repeated '/' or '\\\\'", fixed = TRUE, strict = TRUE)
+expect_silent(
+  expect_true(is_path(path = file.path(fs::path_wd("subdir"), "\\filename.txt"))))
 
-expect_warning(
-  expect_false(is_path(path = file.path(fs::path_wd("subdir"), "\\\\filename.txt"))),
-  pattern = "not contain repeated '/' or '\\\\'", fixed = TRUE, strict = TRUE)
+expect_silent(
+  expect_true(is_path(path = file.path(fs::path_wd("subdir"), "\\\\filename.txt"))))
 
 ##### Trailing file separators #####
 # To prevent warning about repeated file separators on MacOS and Ubuntu (where

--- a/inst/tinytest/test_is_path.R
+++ b/inst/tinytest/test_is_path.R
@@ -10,126 +10,184 @@ warn_space_dot <- "should not end with ' ' or '.'"
 #### Test the examples ####
 expect_true(is_path(getwd()))
 expect_true(is_path(fs::path_wd("abcd")))
-expect_error(is_path(fs::path_wd("ab|cd")),
-             pattern = "should not contain '\"', '*'", fixed = TRUE)
+expect_warning(
+  expect_false(is_path(fs::path_wd("ab|cd"))),
+  pattern = "should not contain '\"', '*'", fixed = TRUE)
 
 expect_true(is_path(fs::path_wd("abcd.txt")))
 expect_true(is_path(fs::path_wd("abcd.txt.gz")))
 expect_true(is_path(fs::path_wd("abcd.gz")))
 
-expect_error(is_path(fs::path_wd("ab:cd.txt")),
-             pattern = "'filename' should not contain ':'", fixed = TRUE)
-expect_error(is_path(fs::path_wd("ab|cd.txt")),
-             pattern = "should not contain '\"', '*'", fixed = TRUE)
+expect_warning(
+  expect_false(is_path(fs::path_wd("ab:cd.txt"))),
+  pattern = "'filename' should not contain ':'", fixed = TRUE)
+
+expect_warning(
+  expect_false(is_path(fs::path_wd("ab|cd.txt"))),
+  pattern = "should not contain '\"', '*'", fixed = TRUE)
 
 
 #### Tests ####
 ##### Illegal characters #####
 for(illegal_char in illegal_chars) {
-  expect_error(is_path(path = fs::path_wd(paste0("ab", illegal_char, "cd"))),
-               pattern = "should not contain '\"', '*'", fixed = TRUE)
+  expect_warning(
+    expect_false(is_path(path = fs::path_wd(paste0("ab", illegal_char, "cd")))),
+    pattern = "should not contain '\"', '*'", fixed = TRUE)
 }
 
 for(illegal_char in illegal_chars) {
-  expect_error(is_path(path = fs::path_wd(paste0("ab", illegal_char, "cd.txt"))),
-               pattern = "should not contain '\"', '*'", fixed = TRUE)
+  expect_warning(
+    expect_false(is_path(path = fs::path_wd(paste0("ab", illegal_char, "cd.txt")))),
+    pattern = "should not contain '\"', '*'", fixed = TRUE)
 }
 
-expect_error(is_path(path = fs::path_wd("ab:cd.txt")),
-             pattern = "'filename' should not contain ':'", fixed = TRUE)
+expect_warning(
+  expect_false(is_path(path = fs::path_wd("ab:cd.txt"))),
+  pattern = "'filename' should not contain ':'", fixed = TRUE)
 
 for(control_char in paste0("\005", "\025", "\035", "\177")) {
-  expect_error(is_path(path = fs::path_wd(paste0("ab", control_char, "cd"))),
-               pattern = "should not contain control characters", fixed = TRUE)
-  expect_error(is_path(path = fs::path_wd(paste0("ab", control_char, "cd.txt"))),
-               pattern = "should not contain control characters", fixed = TRUE)
+  expect_warning(
+    expect_false(is_path(path = fs::path_wd(paste0("ab", control_char, "cd")))),
+    pattern = "should not contain control characters", fixed = TRUE)
+
+  expect_warning(
+    expect_false(is_path(path = fs::path_wd(paste0("ab", control_char, "cd.txt")))),
+    pattern = "should not contain control characters", fixed = TRUE)
 }
 
 ##### Windows reserved names #####
 # These are not allowed as path components but are allowed as filename
 for(Windows_name in Windows_reserved) {
-  expect_error(is_path(path = fs::path_wd(Windows_name)),
-               pattern = warn_Windows_reserved, fixed = TRUE)
-  expect_error(is_path(path = fs::path_wd("subdir", Windows_name, "filename.txt")),
-               pattern = warn_Windows_reserved, fixed = TRUE)
-  expect_true(is_path(path = fs::path_wd("subdir", paste0(Windows_name, ".txt"),
-                                         "filename.txt")))
-  expect_true(is_path(path = fs::path_wd("subdir", paste0(Windows_name, ".txt"))))
+  expect_warning(
+    expect_false(is_path(path = fs::path_wd(Windows_name))),
+    pattern = warn_Windows_reserved, fixed = TRUE)
+
+  expect_warning(
+    expect_false(is_path(path = fs::path_wd("subdir", Windows_name, "filename.txt"))),
+    pattern = warn_Windows_reserved, fixed = TRUE)
+
+  expect_true(
+    is_path(path = fs::path_wd("subdir", paste0(Windows_name, ".txt"),
+                               "filename.txt")))
+
+  expect_true(
+    is_path(path = fs::path_wd("subdir", paste0(Windows_name, ".txt"))))
 }
 
 # 'COM', 'COM0', 'LPT' and 'LPT0' are allowed as filename and as path component
 for(Windows_allowed in c("COM", "COM0", "LPT", "LPT0")) {
-  expect_true(is_path(path = fs::path_wd(Windows_allowed)))
-  expect_true(is_path(path = fs::path_wd("subdir", Windows_allowed, "filename.txt")))
-  expect_true(is_path(path = fs::path_wd("subdir", paste0(Windows_allowed, ".txt"),
-                                         "filename.txt")))
-  expect_true(is_path(path = fs::path_wd("subdir", paste0(Windows_allowed, ".txt"))))
+  expect_true(
+    is_path(path = fs::path_wd(Windows_allowed)))
+
+  expect_true(
+    is_path(path = fs::path_wd("subdir", Windows_allowed, "filename.txt")))
+
+  expect_true(
+    is_path(path = fs::path_wd("subdir", paste0(Windows_allowed, ".txt"),
+                               "filename.txt")))
+
+  expect_true(
+    is_path(path = fs::path_wd("subdir", paste0(Windows_allowed, ".txt"))))
 }
 
 ##### Spaces and dots #####
 # Path elements should not end with a space
 expect_true(is_path(fs::path("a b", "def")))
+
 expect_true(is_path(fs::path("a  b", "def")))
-expect_error(is_path(path = fs::path("ab", " ", "def")),
-             pattern = warn_space_dot, fixed = TRUE)
-expect_error(is_path(path = fs::path("ab", "  ", "def")),
-             pattern = warn_space_dot, fixed = TRUE)
-expect_error(is_path(path = fs::path("ab ", "def")),
-             pattern = warn_space_dot, fixed = TRUE)
-expect_error(is_path(path = fs::path("ab  ", "def")),
-             pattern = warn_space_dot, fixed = TRUE)
-expect_error(is_path(path = fs::path("ab", "def ")),
-             pattern = warn_space_dot, fixed = TRUE)
-expect_error(is_path(path = fs::path("ab", "def ")),
-             pattern = warn_space_dot, fixed = TRUE)
+
+expect_warning(
+  expect_false(is_path(path = fs::path("ab", " ", "def"))),
+  pattern = warn_space_dot, fixed = TRUE)
+
+expect_warning(
+  expect_false(is_path(path = fs::path("ab", "  ", "def"))),
+  pattern = warn_space_dot, fixed = TRUE)
+
+expect_warning(
+  expect_false(is_path(path = fs::path("ab ", "def"))),
+  pattern = warn_space_dot, fixed = TRUE)
+
+expect_warning(
+  expect_false(is_path(path = fs::path("ab  ", "def"))),
+  pattern = warn_space_dot, fixed = TRUE)
+
+expect_warning(
+  expect_false(is_path(path = fs::path("ab", "def "))),
+  pattern = warn_space_dot, fixed = TRUE)
+
+expect_warning(
+  expect_false(is_path(path = fs::path("ab", "def "))),
+  pattern = warn_space_dot, fixed = TRUE)
 
 # "." and ".." are only allowed as first path component
 expect_true(is_path(fs::path(".", "a.b", "def")))
+
 expect_true(is_path(fs::path("..", "a..b", "def")))
-expect_error(is_path(path = fs::path("ab", "..", "def")),
-             pattern = warn_space_dot, fixed = TRUE)
-expect_error(is_path(path = fs::path("ab", ".", "def")),
-             pattern = warn_space_dot, fixed = TRUE)
+
+expect_warning(
+  expect_false(is_path(path = fs::path("ab", "..", "def"))),
+  pattern = warn_space_dot, fixed = TRUE)
+
+expect_warning(
+  expect_false(is_path(path = fs::path("ab", ".", "def"))),
+  pattern = warn_space_dot, fixed = TRUE)
 
 # Path elements should not end with a dot
-expect_error(is_path(path = fs::path("ab.", "def")),
-             pattern = warn_space_dot, fixed = TRUE)
-expect_error(is_path(path = fs::path("ab..", "def")),
-             pattern = warn_space_dot, fixed = TRUE)
-expect_error(is_path(path = fs::path("ab", "def.")),
-             pattern = warn_space_dot, fixed = TRUE)
-expect_error(is_path(path = fs::path("ab", "def..")),
-             pattern = warn_space_dot, fixed = TRUE)
+expect_warning(
+  expect_false(is_path(path = fs::path("ab.", "def"))),
+  pattern = warn_space_dot, fixed = TRUE)
+
+expect_warning(
+  expect_false(is_path(path = fs::path("ab..", "def"))),
+  pattern = warn_space_dot, fixed = TRUE)
+
+expect_warning(
+  expect_false(is_path(path = fs::path("ab", "def."))),
+  pattern = warn_space_dot, fixed = TRUE)
+
+expect_warning(
+  expect_false(is_path(path = fs::path("ab", "def.."))),
+  pattern = warn_space_dot, fixed = TRUE)
 
 # Filenames should not end with a space or a dot
-expect_error(is_path(path = fs::path_wd("subdir", "filename ")),
-             pattern = warn_space_dot, fixed = TRUE)
-expect_error(is_path(path = fs::path_wd("subdir", "filename .txt")),
-             pattern = warn_space_dot, fixed = TRUE)
-expect_error(is_path(path = fs::path_wd("subdir", "filename.")),
-             pattern = warn_space_dot, fixed = TRUE)
-expect_error(is_path(path = fs::path_wd("subdir", "filename..txt")),
-             pattern = warn_space_dot, fixed = TRUE)
+expect_warning(
+  expect_false(is_path(path = fs::path_wd("subdir", "filename "))),
+  pattern = warn_space_dot, fixed = TRUE)
+
+expect_warning(
+  expect_false(is_path(path = fs::path_wd("subdir", "filename .txt"))),
+  pattern = warn_space_dot, fixed = TRUE)
+
+expect_warning(
+  expect_false(is_path(path = fs::path_wd("subdir", "filename."))),
+  pattern = warn_space_dot, fixed = TRUE)
+
+expect_warning(
+  expect_false(is_path(path = fs::path_wd("subdir", "filename..txt"))),
+  pattern = warn_space_dot, fixed = TRUE)
 
 ##### Temporary directory #####
-expect_error(is_path(path = tempdir()),
-             pattern = "'path' should not point to 'tempdir()'", fixed = TRUE)
+expect_warning(
+  expect_false(is_path(path = tempdir())),
+  pattern = "'path' should not point to 'tempdir()'", fixed = TRUE)
+
 expect_true(is_path(fs::path(tempdir(), "subdir")))
 
 
 ##### Repeated file separators #####
 # Need file.path() because fs::path_wd() removes repeated file separators
 expect_warning(
-  expect_true(is_path(path = file.path(fs::path_wd("subdir"), "/filename.txt"))),
-  pattern = "Repeated '/' or '\\\\' in", fixed = TRUE, strict = TRUE)
+  expect_false(is_path(path = file.path(fs::path_wd("subdir"), "/filename.txt"))),
+  pattern = "not contain repeated '/' or '\\\\'", fixed = TRUE, strict = TRUE)
 
 expect_warning(
-  expect_true(is_path(path = file.path(fs::path_wd("subdir"), "\\filename.txt"))),
-  pattern = "Repeated '/' or '\\\\' in", fixed = TRUE, strict = TRUE)
+  expect_false(is_path(path = file.path(fs::path_wd("subdir"), "\\filename.txt"))),
+  pattern = "not contain repeated '/' or '\\\\'", fixed = TRUE, strict = TRUE)
 
 expect_warning(
-  expect_true(is_path(path = file.path(fs::path_wd("subdir"), "\\\\filename.txt"))),
-  pattern = "Repeated '/' or '\\\\' in", fixed = TRUE, strict = TRUE)
+  expect_false(is_path(path = file.path(fs::path_wd("subdir"), "\\\\filename.txt"))),
+  pattern = "not contain repeated '/' or '\\\\'", fixed = TRUE, strict = TRUE)
 
 ##### Trailing file separators #####
 # To prevent warning about repeated file separators on MacOS and Ubuntu (where

--- a/man/is_path.Rd
+++ b/man/is_path.Rd
@@ -10,8 +10,8 @@ is_path(path)
 \item{path}{\link[=is_character]{character string} with the path.}
 }
 \value{
-\code{TRUE}: an error occurs if \code{path} is not a valid path or if \code{path} contains a
-file extension but the filename is not valid.
+\code{TRUE} or \code{FALSE} indicating if \code{path} is a valid path, possibly containing a
+valid filename.
 }
 \description{
 Check that \code{x} is a path that is likely to be valid.
@@ -23,6 +23,8 @@ valid paths before creating a directory or a file:
 \item \code{path} should \strong{not} contain the characters \verb{"}, \code{*}, \verb{?}, \code{|}, \code{<}, \code{>},
 nor any of the control characters (\code{ASCII} octal codes 000 through 037 and
 177, see \code{help("regex")}).
+\item \code{path} should \strong{not} contain repeated file separators (e.g., \verb{//} or
+\verb{\\\\\\\\}).
 \item \code{path} components (i.e., parts separated by file separators \code{/} or \verb{\\\\})
 should \strong{not} be the Windows-reserved terms \code{CON}, \code{PRN}, \code{AUX}, \code{NUL},
 \verb{COM<non-zero digit>}, \verb{LPT<non-zero digit>}, case-insensitive variants of
@@ -50,8 +52,7 @@ reserved names in Windows.
 \code{path} does \strong{not} have to point to an existing directory: \code{path} even does
 \strong{not} have to contain a file separator (e.g., \code{/} or \verb{\\\\}), such that
 \code{is_path()} can be used to check that input to \code{\link[fs:path]{fs::path()}} only contains
-allowed characters. Repeated file separators (e.g., \verb{//} or \verb{\\\\\\\\}) are
-treated as single separators, with a warning.
+allowed characters.
 }
 \section{Programming notes}{
 
@@ -91,14 +92,14 @@ removed in some operations.
 \examples{
 is_path(getwd())
 is_path(fs::path_wd("abcd"))
-try(is_path(fs::path_wd("ab|cd")))
+is_path(fs::path_wd("ab|cd"))
 
 is_path(fs::path_wd("abcd.txt"))
 is_path(fs::path_wd("abcd.txt.gz"))
 is_path(fs::path_wd("abcd.gz"))
 
-try(is_path(fs::path_wd("ab:cd.txt")))
-try(is_path(fs::path_wd("ab|cd.txt")))
+is_path(fs::path_wd("ab:cd.txt"))
+is_path(fs::path_wd("ab|cd.txt"))
 
 }
 \seealso{

--- a/man/is_path.Rd
+++ b/man/is_path.Rd
@@ -7,76 +7,84 @@
 is_path(path)
 }
 \arguments{
-\item{path}{\link[=is_character]{character string} with the path.}
+\item{path}{\link[=is_character]{character string} with the path, possibly
+containing a valid filename.}
 }
 \value{
 \code{TRUE} or \code{FALSE} indicating if \code{path} is a valid path, possibly containing a
 valid filename.
 }
 \description{
-Check that \code{x} is a path that is likely to be valid.
+Check that \code{x} is a valid path, possibly containing a valid filename.
 }
 \details{
-\code{is_path()} puts restrictions on paths so it can be used to check for
-valid paths before creating a directory or a file:
+\code{is_path()} is intended to be used to check for valid paths before creating a
+directory or a file. Therefore it imposes the following restrictions:
 \itemize{
 \item \code{path} should \strong{not} contain the characters \verb{"}, \code{*}, \verb{?}, \code{|}, \code{<}, \code{>},
 nor any of the control characters (\code{ASCII} octal codes 000 through 037 and
 177, see \code{help("regex")}).
-\item \code{path} should \strong{not} contain repeated file separators (e.g., \verb{//} or
-\verb{\\\\\\\\}).
 \item \code{path} components (i.e., parts separated by file separators \code{/} or \verb{\\\\})
 should \strong{not} be the Windows-reserved terms \code{CON}, \code{PRN}, \code{AUX}, \code{NUL},
 \verb{COM<non-zero digit>}, \verb{LPT<non-zero digit>}, case-insensitive variants of
 these names, or these names followed by an extension.
-\item \code{path} components
-should \strong{not} end with a space or dot (\code{"."} and \code{".."} are allowed as
-first component to indicate the working directory and the parent directory,
-respectively).
+\item \code{path} components should \strong{not} end with a space.
+\item \code{path} components should \strong{not} end with a dot, with the exception of
+\code{"."} and \code{".."} that are allowed as first component to indicate the
+working directory and the parent directory, respectively.
 \item \code{path} should not point to \code{tempdir()}: a temporary subdirectory should be
 used instead (see \code{progutils::create_tempdir()}).
+\item If \code{path} contains a file extension (or compression extension, the current
+implementation does not distinguish those from each other), the part after
+the last slash is considered the filename, which \strong{should} adhere to the
+restrictions listed above, and in addition should \strong{not} contain \code{:}
+\strong{nor} start with a space or a hyphen (\code{-}), while it \strong{might} contain
+the Windows-reserved terms given in the second point above.
 }
 
-Furthermore, if \code{path} contains a file extension or compression extension,
-the part after the last
-slash is considered the filename, which should adhere to the same
-restrictions as the path but should \strong{not} contain \code{:} \strong{nor}
-start with a space, while it might contain Windows-reserved terms.
+These restrictions \code{path} consider characters and words that are not allowed
+in Windows and thus would lead to an error when used to create a directory or
+file; and characters that are silently removed in Windows and thus would lead
+to a mismatch between the created directory and the returned path when used
+to create a directory.
 
-These restrictions on the path and the filename consider characters that
-would lead to an error in Windows because they are not allowed; characters
-that would lead to a mismatch between the created directory and the returned
-path because they are silently removed in Windows; and words that are
-reserved names in Windows.
-
-\code{path} does \strong{not} have to point to an existing directory: \code{path} even does
-\strong{not} have to contain a file separator (e.g., \code{/} or \verb{\\\\}), such that
-\code{is_path()} can be used to check that input to \code{\link[fs:path]{fs::path()}} only contains
-allowed characters.
+\code{is_path()} allows some patterns that will not occur in real (i.e., existing)
+paths or filenames:
+\itemize{
+\item \code{path} does \strong{not} have to contain a file separator (i.e., \code{/} or \verb{\\\\}).
+This makes it possible to use \code{is_path()} to check that input to
+\code{\link[fs:path]{fs::path()}} only contains allowed characters.
+\item \code{path} does \strong{not} have to point to an existing directory (see the
+previous point).
+\item \code{path} might contain repeated file separators (e.g., \verb{//} or \verb{\\\\\\\\}): these
+will be treated as if they were only a single file separator.
+\item \code{path} might contain trailing file separators, even though these might be
+ignored or removed in some operations (e.g., they are removed by \code{\link[=file.path]{file.path()}}
+and \code{\link[fs:path]{fs::path()}})
+.
+}
 }
 \section{Programming notes}{
-
-On MacOS, the output of \code{tempdir()} is preceded by duplicated forward slashes
-in R cmd checks (e.g., \verb{/var/[...]/T//RtmpxC2Fyl/working_dir/RtmpdnqgUR}),
-leading to a spurious warning from \code{is_path()}.
 
 The file separator is a backslash (\verb{\\}) on Windows but a forward slash (\code{/})
 on other operating systems (\link[=.Platform]{.Platform$file.sep} gives the file
 separator used on the current platform). Furthermore, the backslash is used
 as \link[=regex]{escape character} in \R, such that backslashes need to be escaped
-in \R code. Thus, to warn if a \link[=is_character]{string} contains
-a file separator, one should write the warning message as
-\code{warning("Repeated '/' or '\\\\'")} which will be printed as
-\verb{Repeated '/' or '\\'}. Checks on the presence of slashes and backslashes
-should use \code{grepl(pattern = "/", x = string)} and
-\code{grepl(pattern = "\\\\\\\\", x = string)}. This makes it cumbersome to get the
-correct type and number of slashes to compare with the path recorded in a
-warning message, such that it is more robust to check only for fixed parts of
-the message (e.g., \code{"Repeated"}), possibly followed by a check like
+in \R code. Thus, a check on the presence of repeated slashes and backslashes
+in \link[=is_character]{string} \code{string} would use
+\code{grepl(pattern = "//", x = string, fixed = TRUE)} and
+\code{grepl(pattern = "\\\\\\\\", x = string, fixed = TRUE)}. The message to point out
+their presence would be written as \code{message("Repeated '/' or '\\\\'")} which
+would be printed as \verb{Repeated '/' or '\\'}. This makes it cumbersome to get
+the correct type and number of slashes to compare with the path recorded in a
+message, such that it is more robust to check only for fixed parts of the
+message (e.g., \code{"Repeated"}), possibly followed by a check like
 \code{tinytest::expect_true(dir.exists(string))}.
 
-Trailing slashes or backslashes are allowed, even though these might be
-removed in some operations.
+On MacOS, the output of \code{tempdir()} is preceded by duplicated forward slashes
+(e.g., \verb{/var/[...]/T//RtmpxC2Fyl/working_dir/RtmpdnqgUR}) which led to
+spurious warnings in earlier versions of \code{is_path()} that warned about
+duplicated file separators.
 }
 
 \section{References}{
@@ -84,6 +92,13 @@ removed in some operations.
 \itemize{
 \item Naming files, paths, and namespaces from
 \href{https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file}{Microsoft}
+\item Entries
+\href{https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap03.html#tag_03_146}{Filename},
+\href{https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap03.html#tag_03_264}{Portable filenames}
+and
+\href{https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap03.html#tag_03_254}{Pathname}
+from the Posix standard
+\href{https://pubs.opengroup.org/onlinepubs/9799919799/}{POSIX.1-2024}
 \item Comparison of file systems from
 \href{https://en.wikipedia.org/wiki/Comparison_of_file_systems#Limits}{Wikipedia}
 }


### PR DESCRIPTION
`is_path()`: adjusted to warn and return `FALSE` instead of throwing an error if `path` is not a valid path.