### PR TITLE
checkinput 0.10.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,6 +16,8 @@ Suggests:
     progutils (>= 0.0.4),
     rmarkdown,
     tinytest (>= 1.4.1)
+Remotes:
+    github::JesseAlderliesten/progutils
 URL: https://github.com/JesseAlderliesten/checkinput, https://jessealderliesten.github.io/checkinput/
 BugReports: https://github.com/JesseAlderliesten/checkinput/issues
 VignetteBuilder: knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: checkinput
 Title: Check Function Input
-Version: 0.9.0
+Version: 0.10.0
 Authors@R: 
     person("Jesse", "Alderliesten", email = "jessealderliesten@hotmail.com",
     role = c("aut", "cre"), comment = c(ORCID = "0000-0003-1132-4310"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,6 +13,7 @@ Imports:
     fs
 Suggests: 
     knitr,
+    progutils (>= 0.0.4),
     rmarkdown,
     tinytest (>= 1.4.1)
 URL: https://github.com/JesseAlderliesten/checkinput, https://jessealderliesten.github.io/checkinput/

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,20 @@
+# checkinput 0.10.0
+
+### Breaking changes
+- Add dependency `progutils >= 0.0.4` to `Suggests` because it is used in the
+  documentation.
+
+### Bugfixes
+- `is_path("C:")` would warn that filename should not contain `:`.
+
+### Documentation
+- `paste_quoted()`: document that `paste_quoted()` warns about dropping names.
+
+
 # checkinput 0.9.0
 
 ### Breaking changes
-- Added dependency `fs` that is used in `is_path()`.
+- Add dependency `fs` to `Imports` because it is used in `is_path()`.
 - `paste_quoted()` now accepts atomic non-vector objects such as the output of
   `fs::path()`.
 
@@ -70,7 +83,7 @@
 
 ### Breaking changes
 - Dependency `R` >= 4.0.0 increased to `R` >= 4.1.0, which is required to pass
-  the R CMD check on ubuntu-latest: `rmarkdown` > `bslib` > `sass` > `fs` needs
+  the R CMD check on Ubuntu-latest: `rmarkdown` > `bslib` > `sass` > `fs` needs
   `R` >= 4.1 and `rappdirs` needs `R` >= 4.1.
 - `all_names()`: wrap text of warnings. Use `deparse1(substitute(x))` to get the
   offending values instead of literal `'x'` in the text of warnings or errors.
@@ -115,8 +128,8 @@
 # checkinput 0.0.6
 
 ### Breaking changes
-- Added `vctrs` as dependency in `Suggests` because it is used in documentation
-  of `all_names()`.
+- Add dependency `vctrs` to `Suggests` because it is used in documentation of
+  `all_names()`.
 - `all_names()`: remove argument `allow_susp` and never allows suspicious names
   because allowing them amounts to only checking for syntactically invalid names,
   for which `make.names()` can be used directly; do not try to identify which
@@ -134,7 +147,7 @@
   and thus to an error.
 
 ### Documentation
-- `all_names()`: major updates and restructuring. Also updated and added examples.
+- `all_names()`: major updates and restructuring. Update and add examples.
 - `README`: add a reference to my repository `checkrpkgs`. Clarify that
   functions **do** throw errors about invalid input to arguments other than `x`.
 - Vignette `design_choices`: clarified that functions **do** throw errors about

--- a/R/all_names.R
+++ b/R/all_names.R
@@ -107,8 +107,8 @@
 #' collections of checks on type and length
 #'
 #' @examples
-#' all_names(x = c("a", "b1a")) # TRUE
-#' all_names(x = c("a", "b1a", "a")) # FALSE: duplicated name
+#' all_names(x = c("a", "b2a")) # TRUE
+#' all_names(x = c("a", "b2a", "a")) # FALSE: duplicated name
 #'
 #' invalid_names <- c("a", "ab#cd", "", "for", "..", "..23")
 #' # Syntactically invalid names: the character '#' makes names invalid,

--- a/R/is_natural.R
+++ b/R/is_natural.R
@@ -55,10 +55,10 @@
 #' collections of checks on type and length
 #'
 #' @seealso
-#' `progutils::are_equal()` to check for element-wise near-equality of numbers;
+#' [progutils::are_equal()] to check for element-wise near-equality of numbers;
 #' [all.equal()] to check more generally for near-equality; [identical()] to
 #' check for exact equality and [Comparison] to do so using binary operators;
-#' [match()] and `progutils::not_in()` to compare character vectors; [\R FAQ 7.31](
+#' [match()] and [progutils::not_in()] to compare character vectors; [\R FAQ 7.31](
 #' https://CRAN.R-project.org/doc/manuals/R-FAQ.html#Why-doesn_0027t-R-think-these-numbers-are-equal_003f)
 #' for background on numerical equality.
 #'

--- a/R/is_natural.R
+++ b/R/is_natural.R
@@ -37,15 +37,15 @@
 #' error if `x` is not natural according to `is_natural(x)` or `all_natural(x)`,
 #' respectively.
 #'
-#' The code of `is_natural()` and `all_natural()` is partly based on the example
-#' `is.wholenumber()` in [is.integer()].
-#'
-#' @section Programming notes:
 #' Use of `is_natural(x)` or `all_natural(x)` inside [stopifnot()] should be
 #' followed by assigning the rounded value to the argument:
 #' `x <- as.integer(round(x))`. Alternatively, use `make_natural(x)` and assign
 #' the result to `x` (then there is no need to use [stopifnot()]:
 #' `make_natural()` throws an error if `x` is not natural).
+#'
+#' @section Programming notes:
+#' The code of `is_natural()` and `all_natural()` is partly based on the example
+#' `is.wholenumber()` in [is.integer()].
 #'
 #' [is.integer()] does **not** check that `x` is a natural number (nor if `x` is
 #' a whole number) but rather that `x` is of [type][typeof()] integer, see the

--- a/R/is_path.R
+++ b/R/is_path.R
@@ -53,13 +53,16 @@
 #' `TRUE` or `FALSE` indicating if `x` is a valid path, possibly containing a
 #' valid filename.
 #'
-#' @section Programming notes:
+#' @section Notes on paths:
 #' The file separator is a backslash (`\`) on Windows but a forward slash (`/`)
 #' on other operating systems ([.Platform$file.sep][.Platform] gives the file
-#' separator used on the current platform). Furthermore, the backslash is used
+#' separator used on the current platform).
+#'
+#' Furthermore, the backslash is used
 #' as [escape character][regex] in \R, such that backslashes need to be escaped
-#' in \R code. Thus, a check on the presence of repeated slashes and backslashes
-#' in [string][is_character()] `string` would use
+#' in \R code by doubling them (use `cat(x)` to see how x would be printed).
+#' Thus, a check on the presence of repeated
+#' slashes and backslashes in [string][is_character()] `string` would use
 #' `grepl(pattern = "//", x = string, fixed = TRUE)` and
 #' `grepl(pattern = "\\\\", x = string, fixed = TRUE)`. The message to point out
 #' their presence would be written as `message("Repeated '/' or '\\'")` which
@@ -69,6 +72,7 @@
 #' message (e.g., `"Repeated"`), possibly followed by a check like
 #' `tinytest::expect_true(fs::dir_exists(string))`.
 #'
+#' @section Programming notes:
 #' The output of `tempdir()` during R cmd checks on MacOS contains duplicated
 #' forward slashes (e.g., `/var/[...]/T//RtmpxC2Fyl/working_dir/RtmpdnqgUR`)
 #' which in earlier versions of `is_path()` (then in package `progutils`) led to
@@ -95,6 +99,10 @@
 #' if it does not yet exist; [progutils::create_dir()] to create a directory if
 #' it does not yet exist; [progutils::get_file_path()] to check if a file exists
 #' and is a unique match to a pattern.
+#'
+#' Section 'Paths in the shell' in the vignette *Git and GitHub* of package
+#' `checkrpkgs`: `vignette("git_github", package = "checkrpkgs")` on paths and
+#' file separators in the [shell](https://happygitwithr.com/shell).
 #'
 #' @family
 #' collections of checks on type and length

--- a/R/is_path.R
+++ b/R/is_path.R
@@ -24,15 +24,16 @@
 #' - If `x` contains a file extension (or compression extension, the current
 #'   implementation does not distinguish those from each other), the part after
 #'   the last slash is considered the filename, which **should** adhere to the
-#'   restrictions listed above, and in addition should **not** contain `:`
-#'   **nor** start with a space or a hyphen (`-`), while it **might** contain
-#'   the Windows-reserved terms given in the second point above.
+#'   restrictions listed above (although it **may** contain the Windows-reserved
+#'   terms listed in the second point above), and in addition should **not**
+#'   contain `:` **nor** start with a space or a hyphen (`-`).
 #'
 #' These restrictions on `x` consider characters and words that are not allowed
 #' in Windows and thus would lead to an error when used to create a directory or
-#' file; and characters that are silently removed in Windows and thus would lead
+#' file; characters that are silently removed in Windows and thus would lead
 #' to a mismatch between the created directory and the returned path when used
-#' to create a directory.
+#' to create a directory; and characters that might give problems when used in
+#' the shell.
 #'
 #' `is_path()` allows some patterns that will not occur in real (i.e., existing)
 #' paths or filenames:
@@ -87,12 +88,12 @@
 #'   [Wikipedia](https://en.wikipedia.org/wiki/Comparison_of_file_systems#Limits)
 #'
 #' @seealso
-#' [fs::path_math] for various operations on paths; [fs::path_sanitize()] to
+#' [fs::path_math()] for various operations on paths; [fs::path_sanitize()] to
 #' **remove** invalid characters from potential paths;
 #' [utils::file_test()] and references there on file existence and permissions;
-#' `progutils::create_file_path()` to create a file path, creating the directory
-#' if it does not yet exist; `progutils::create_dir()` to create a directory if
-#' it does not yet exist; `progutils::get_file_path()` to check if a file exists
+#' [progutils::create_file_path()] to create a file path, creating the directory
+#' if it does not yet exist; [progutils::create_dir()] to create a directory if
+#' it does not yet exist; [progutils::get_file_path()] to check if a file exists
 #' and is a unique match to a pattern.
 #'
 #' @family
@@ -107,15 +108,20 @@
 #' is_path(fs::path_wd("abcd.txt.gz"))
 #' is_path(fs::path_wd("abcd.gz"))
 #'
-#' is_path(fs::path_wd("ab:cd.txt"))
-#' is_path(fs::path_wd("ab|cd.txt"))
+#' # ':' is allowed in paths but not in filenames
+#' is_path(fs::path_wd("ab:cd")) # TRUE
+#' is_path(fs::path_wd("ab:cd.txt")) # FALSE
+#'
+#' # Other illegal characters are not allowed in either paths or filenames
+#' is_path(fs::path_wd("ab|cd")) # FALSE
+#' is_path(fs::path_wd("ab|cd.txt")) # FALSE
 #'
 #' @export
 is_path <- function(x) {
   arg_name <- paste_quoted(deparse(substitute(x)))
 
   if(!is_character(x)) {
-    warning(arg_name, " should be a character string:\n", x)
+    warning(arg_name, " should be a non-empty, non-NA_character_ character string:\n", x)
     # Return early for non-character input to prevent spurious errors.
     return(FALSE)
   }
@@ -173,7 +179,8 @@ is_path <- function(x) {
   file_ext <- fs::path_ext(path = filename)
   filename_no_ext <- fs::path_ext_remove(path = filename)
   has_file_ext <- (length(file_ext) != 0L && nzchar(file_ext)) ||
-    filename != filename_no_ext ||
+    # fs::path() needed because fs::path_ext_remove() tidies the path
+    fs::path(filename) != filename_no_ext ||
     # Catch case where filename ends in a dot (e.g., "ff..txt") on Windows with
     # R 4.1.0: modified from fs::path_ext_remove() to only remove a single dot
     grepl(pattern = "\\.([^.]+)$", x = filename, perl = TRUE)

--- a/R/paste_quoted.R
+++ b/R/paste_quoted.R
@@ -1,6 +1,6 @@
 #' Quote and concatenate x to a string
 #'
-#' Quote elements of an atomic object without dimensions and concatenate the
+#' Quote elements of a dimensionless atomic object and concatenate the
 #' result to a single character string.
 #'
 #' @details
@@ -9,7 +9,7 @@
 #' `NA`s as `"'NA_<class>_'"` (e.g., `"'NA_real_'"`; for [factors][factor] this
 #' is `"'NA_character_'"`).
 #'
-#' @param x Atomic object without dimensions to be converted to a single
+#' @param x Dimensionless atomic object to be converted to a single
 #' character string.
 #'
 #' @returns
@@ -23,9 +23,12 @@
 #' `paste_quoted("a", "b")` will return the error `unused argument ("b")`. The
 #' probably intended call is `paste_quoted(c("a", "b"))`, returning `"'a', 'b'"`.
 #'
+#' `paste_quoted()` drops [names][names()] of `x`, which is pointed out in a
+#' [warning][warning()] if `x` has names.
+#'
 #' @seealso
 #' [toString()] which can be used instead of `paste(x, collapse = ", ")`,
-#' [sQuote()] to use fancy quotes, [paste0()], `progutils::unpaste_unquote()`
+#' [sQuote()] to use fancy quotes, [paste0()], [progutils::unpaste_unquote()]
 #' for the approximate opposite of `paste_quoted()`.
 #'
 #' @family functions to modify character vectors

--- a/README.Rmd
+++ b/README.Rmd
@@ -17,7 +17,8 @@ knitr::opts_chunk$set(
 
 
 # checkinput
-With `checkinput`, you can write concise, flexible checks for input to R functions.
+With `checkinput`, you can write concise, flexible checks for input to R
+functions.
 
 ## Installation
 Visit the [checkinput website](https://jessealderliesten.github.io/checkinput/)
@@ -56,7 +57,7 @@ The checks inside `stopifnot()` ensure that (1) `name` contains a single
 character string that might be empty (`""`) or character-type `NA` 
 (`NA_character_`) if people do not want to give their name; (2) `age` contains a
 single non-negative number; (3) `hobbies` contains at least one character string
-and does not contain any empty strings or `NA`s.
+and does not contain empty strings or `NA`s.
 
 The base R equivalent of `list_hobbies()` would require much more code to check
 the input, increasing the chance of coding errors and making it more difficult
@@ -90,14 +91,12 @@ baby_base <- list_hobbies_base(name = "", age = 0, hobbies = hobbies_baby)
 identical(baby_checkinput, baby_base)
 ```
 
-When a check fails, error messages can be more informative when using `checkinput`:
+When a check fails, error messages indicate the offending arguments:
 
 ```{r}
+library(checkinput)
 try(list_hobbies(name = "John", age = 25, hobbies = c(hobbies_John, "")))
-try(list_hobbies_base(name = "John", age = 25, hobbies = c(hobbies_John, "")))
-
 try(list_hobbies(name = "", age = -1, hobbies = hobbies_baby))
-try(list_hobbies_base(name = "", age = -1, hobbies = hobbies_baby))
 ```
 
 ### Design choices
@@ -109,16 +108,16 @@ explained in the
 [vignette about design choices](https://jessealderliesten.github.io/checkinput/articles/design_choices.html):
 `vignette("design_choices", package = "checkinput")`. That vignette also shows
 how to get a named boolean vector indicating for each element of `x` if it is
-`TRUE` or `FALSE` according to `all_<func>(x)`.
+`TRUE` or `FALSE` according to `is_<func>(x)` or `all_<func>(x)`.
 
 `checkinput` also contains a
 [vignette about type coercion](https://jessealderliesten.github.io/checkinput/articles/type_coercion.html)
-in vectors, which discusses some important aspects regarding testing of vectors:
+in relation to the testing of vectors:
 `vignette("type_coercion", package = "checkinput")`.
 
 ## Similar packages
 Functions of `checkinput` use arguments to determine which special values should
-be allowed, which makes them more flexible than functions in similar packages.
+be allowed, making them more flexible than functions in similar packages.
 Nevertheless, the following similar packages are worth looking into:
 
 - [arkhe](https://CRAN.R-project.org/package=arkhe): tools for cleaning

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 
 # checkinput
 
-With `checkinput`, you can write concise but flexible checks for input
-to R functions.
+With `checkinput`, you can write concise, flexible checks for input to R
+functions.
 
 ## Installation
 
@@ -50,7 +50,7 @@ The checks inside `stopifnot()` ensure that (1) `name` contains a single
 character string that might be empty (`""`) or character-type `NA`
 (`NA_character_`) if people do not want to give their name; (2) `age`
 contains a single non-negative number; (3) `hobbies` contains at least
-one character string and does not contain any empty strings or `NA`s.
+one character string and does not contain empty strings or `NA`s.
 
 The base R equivalent of `list_hobbies()` would require much more code
 to check the input, increasing the chance of coding errors and making it
@@ -86,23 +86,16 @@ identical(baby_checkinput, baby_base)
 #> [1] TRUE
 ```
 
-When a check fails, error messages can be more informative when using
-`checkinput`:
+When a check fails, error messages indicate the offending arguments:
 
 ``` r
+library(checkinput)
 try(list_hobbies(name = "John", age = 25, hobbies = c(hobbies_John, "")))
 #> Error in list_hobbies(name = "John", age = 25, hobbies = c(hobbies_John,  : 
 #>   all_characters(hobbies) is not TRUE
-try(list_hobbies_base(name = "John", age = 25, hobbies = c(hobbies_John, "")))
-#> Error in list_hobbies_base(name = "John", age = 25, hobbies = c(hobbies_John,  : 
-#>   all(nzchar(hobbies, keepNA = FALSE)) is not TRUE
-
 try(list_hobbies(name = "", age = -1, hobbies = hobbies_baby))
 #> Error in list_hobbies(name = "", age = -1, hobbies = hobbies_baby) : 
 #>   is_nonnegative(age) is not TRUE
-try(list_hobbies_base(name = "", age = -1, hobbies = hobbies_baby))
-#> Error in list_hobbies_base(name = "", age = -1, hobbies = hobbies_baby) : 
-#>   age >= 0L is not TRUE
 ```
 
 ### Design choices
@@ -115,19 +108,20 @@ are used for `allow_NA`. This is explained in the [vignette about design
 choices](https://jessealderliesten.github.io/checkinput/articles/design_choices.html):
 `vignette("design_choices", package = "checkinput")`. That vignette also
 shows how to get a named boolean vector indicating for each element of
-`x` if it is `TRUE` or `FALSE` according to `all_<func>(x)`.
+`x` if it is `TRUE` or `FALSE` according to `is_<func>(x)` or
+`all_<func>(x)`.
 
 `checkinput` also contains a [vignette about type
 coercion](https://jessealderliesten.github.io/checkinput/articles/type_coercion.html)
-in vectors, which discusses some important aspects regarding testing of
-vectors: `vignette("type_coercion", package = "checkinput")`.
+in relation to the testing of vectors:
+`vignette("type_coercion", package = "checkinput")`.
 
 ## Similar packages
 
 Functions of `checkinput` use arguments to determine which special
-values should be allowed, which makes them more flexible than functions
-in similar packages. Nevertheless, the following similar packages are
-worth looking into:
+values should be allowed, making them more flexible than functions in
+similar packages. Nevertheless, the following similar packages are worth
+looking into:
 
 - [arkhe](https://CRAN.R-project.org/package=arkhe): tools for cleaning
   rectangular data.

--- a/inst/tinytest/test_all_names.R
+++ b/inst/tinytest/test_all_names.R
@@ -92,9 +92,9 @@ note_mknm_dots <- paste0("\n\\(it does not recognise names that consist of only"
 
 
 #### Test the examples ####
-expect_true(all_names(x = c("a", "b1a")))
+expect_true(all_names(x = c("a", "b2a")))
 expect_warning(
-  expect_false(all_names(x = c("a", "b1a", "a"))),
+  expect_false(all_names(x = c("a", "b2a", "a"))),
   pattern = paste0(warn_dupl, "'a'", use_mknm_mult), strict = TRUE, fixed = FALSE)
 
 invalid_names <- c("a", "ab#cd", "", "for", "..", "..23")

--- a/inst/tinytest/test_is_path.R
+++ b/inst/tinytest/test_is_path.R
@@ -18,16 +18,28 @@ expect_true(is_path(fs::path_wd("abcd.txt")))
 expect_true(is_path(fs::path_wd("abcd.txt.gz")))
 expect_true(is_path(fs::path_wd("abcd.gz")))
 
+expect_silent(
+  expect_true(is_path(fs::path_wd("ab:cd"))))
 expect_warning(
   expect_false(is_path(fs::path_wd("ab:cd.txt"))),
   pattern = "should not contain ':'", fixed = TRUE)
 
+expect_warning(
+  expect_false(is_path(fs::path_wd("ab|cd"))),
+  pattern = "should not contain '\"', '*'", fixed = TRUE)
 expect_warning(
   expect_false(is_path(fs::path_wd("ab|cd.txt"))),
   pattern = "should not contain '\"', '*'", fixed = TRUE)
 
 
 #### Tests ####
+##### Miscellaneous #####
+expect_silent(expect_true(is_path(".txt")))
+expect_silent(expect_true(is_path(".gz")))
+expect_silent(expect_true(is_path("abcd")))
+expect_silent(expect_true(is_path("abcd.gz")))
+expect_silent(expect_true(is_path("abc.tx#")))
+
 ##### Illegal characters #####
 for(illegal_char in illegal_chars) {
   expect_warning(
@@ -45,6 +57,10 @@ expect_warning(
 expect_warning(
   expect_false(is_path("ab:cd.txt")),
   pattern = "should not contain ':'", fixed = TRUE)
+
+# fs::path_ext_remove(filename) normalized "C:" to "C:/" leading to the
+# erroneous warning that the filename should not contain ':'.
+expect_silent(expect_true(is_path("C:")))
 
 for(control_char in paste0("\005", "\025", "\035", "\177")) {
   expect_warning(
@@ -156,6 +172,10 @@ expect_warning(
 
 # Filenames should not end with a space or a dot
 expect_warning(
+  expect_false(is_path("..txt")),
+  pattern = warn_space_dot, fixed = TRUE)
+
+expect_warning(
   expect_false(is_path(fs::path_wd("subdir", "filename "))),
   pattern = warn_space_dot, fixed = TRUE)
 
@@ -215,11 +235,18 @@ expect_true(is_path(paste0(fs::path_wd("subdir", "filename.txt"), "\\")))
 ##### Non-character input #####
 expect_warning(
   expect_false(is_path(3)),
-  pattern = "should be a character string", fixed = TRUE)
+  pattern = "should be a non-empty, non-NA_character_ character string",
+  fixed = TRUE)
 
 expect_warning(
   expect_false(is_path(c("abc.txt", "def.html"))),
-  pattern = "should be a character string", fixed = TRUE)
+  pattern = "should be a non-empty, non-NA_character_ character string",
+  fixed = TRUE)
+
+expect_warning(
+  expect_false(is_path(NA_character_)),
+  pattern = "should be a non-empty, non-NA_character_ character string",
+  fixed = TRUE)
 
 
 #### Cleaning up ####

--- a/man/all_names.Rd
+++ b/man/all_names.Rd
@@ -107,8 +107,8 @@ Multiple patterns can be combined using \code{|}, the normal operator indicating
 }
 
 \examples{
-all_names(x = c("a", "b1a")) # TRUE
-all_names(x = c("a", "b1a", "a")) # FALSE: duplicated name
+all_names(x = c("a", "b2a")) # TRUE
+all_names(x = c("a", "b2a", "a")) # FALSE: duplicated name
 
 invalid_names <- c("a", "ab#cd", "", "for", "..", "..23")
 # Syntactically invalid names: the character '#' makes names invalid,

--- a/man/is_natural.Rd
+++ b/man/is_natural.Rd
@@ -78,17 +78,17 @@ representation error. As the \code{Note} at \code{\link{==}} warns, \code{x == r
 error if \code{x} is not natural according to \code{is_natural(x)} or \code{all_natural(x)},
 respectively.
 
-The code of \code{is_natural()} and \code{all_natural()} is partly based on the example
-\code{is.wholenumber()} in \code{\link[=is.integer]{is.integer()}}.
-}
-
-\section{Programming notes}{
-
 Use of \code{is_natural(x)} or \code{all_natural(x)} inside \code{\link[=stopifnot]{stopifnot()}} should be
 followed by assigning the rounded value to the argument:
 \code{x <- as.integer(round(x))}. Alternatively, use \code{make_natural(x)} and assign
 the result to \code{x} (then there is no need to use \code{\link[=stopifnot]{stopifnot()}}:
 \code{make_natural()} throws an error if \code{x} is not natural).
+}
+
+\section{Programming notes}{
+
+The code of \code{is_natural()} and \code{all_natural()} is partly based on the example
+\code{is.wholenumber()} in \code{\link[=is.integer]{is.integer()}}.
 
 \code{\link[=is.integer]{is.integer()}} does \strong{not} check that \code{x} is a natural number (nor if \code{x} is
 a whole number) but rather that \code{x} is of \link[=typeof]{type} integer, see the

--- a/man/is_natural.Rd
+++ b/man/is_natural.Rd
@@ -152,10 +152,10 @@ try(toy_fun_safe(x = 5.1, all = TRUE)) # Error: all_natural(x) is not TRUE
 
 }
 \seealso{
-\code{progutils::are_equal()} to check for element-wise near-equality of numbers;
+\code{\link[progutils:are_equal]{progutils::are_equal()}} to check for element-wise near-equality of numbers;
 \code{\link[=all.equal]{all.equal()}} to check more generally for near-equality; \code{\link[=identical]{identical()}} to
 check for exact equality and \link{Comparison} to do so using binary operators;
-\code{\link[=match]{match()}} and \code{progutils::not_in()} to compare character vectors; \href{https://CRAN.R-project.org/doc/manuals/R-FAQ.html#Why-doesn_0027t-R-think-these-numbers-are-equal_003f}{\R FAQ 7.31}
+\code{\link[=match]{match()}} and \code{\link[progutils:not_in]{progutils::not_in()}} to compare character vectors; \href{https://CRAN.R-project.org/doc/manuals/R-FAQ.html#Why-doesn_0027t-R-think-these-numbers-are-equal_003f}{\R FAQ 7.31}
 for background on numerical equality.
 
 The vignettes \emph{Design choices regarding function input}:

--- a/man/is_path.Rd
+++ b/man/is_path.Rd
@@ -64,14 +64,17 @@ ignored or removed in some operations (e.g., they are removed by
 .
 }
 }
-\section{Programming notes}{
+\section{Notes on paths}{
 
 The file separator is a backslash (\verb{\\}) on Windows but a forward slash (\code{/})
 on other operating systems (\link[=.Platform]{.Platform$file.sep} gives the file
-separator used on the current platform). Furthermore, the backslash is used
+separator used on the current platform).
+
+Furthermore, the backslash is used
 as \link[=regex]{escape character} in \R, such that backslashes need to be escaped
-in \R code. Thus, a check on the presence of repeated slashes and backslashes
-in \link[=is_character]{string} \code{string} would use
+in \R code by doubling them (use \code{cat(x)} to see how x would be printed).
+Thus, a check on the presence of repeated
+slashes and backslashes in \link[=is_character]{string} \code{string} would use
 \code{grepl(pattern = "//", x = string, fixed = TRUE)} and
 \code{grepl(pattern = "\\\\\\\\", x = string, fixed = TRUE)}. The message to point out
 their presence would be written as \code{message("Repeated '/' or '\\\\'")} which
@@ -80,6 +83,9 @@ the correct type and number of slashes to compare with the path recorded in a
 message, such that it is more robust to check only for fixed parts of the
 message (e.g., \code{"Repeated"}), possibly followed by a check like
 \code{tinytest::expect_true(fs::dir_exists(string))}.
+}
+
+\section{Programming notes}{
 
 The output of \code{tempdir()} during R cmd checks on MacOS contains duplicated
 forward slashes (e.g., \verb{/var/[...]/T//RtmpxC2Fyl/working_dir/RtmpdnqgUR})
@@ -130,6 +136,10 @@ is_path(fs::path_wd("ab|cd.txt")) # FALSE
 if it does not yet exist; \code{\link[progutils:create_dir]{progutils::create_dir()}} to create a directory if
 it does not yet exist; \code{\link[progutils:get_file_path]{progutils::get_file_path()}} to check if a file exists
 and is a unique match to a pattern.
+
+Section 'Paths in the shell' in the vignette \emph{Git and GitHub} of package
+\code{checkrpkgs}: \code{vignette("git_github", package = "checkrpkgs")} on paths and
+file separators in the \href{https://happygitwithr.com/shell}{shell}.
 
 Other collections of checks on type and length:
 \code{\link[=all_characters]{all_characters()}},

--- a/man/is_path.Rd
+++ b/man/is_path.Rd
@@ -36,16 +36,17 @@ directory and the parent directory, respectively.
 \item If \code{x} contains a file extension (or compression extension, the current
 implementation does not distinguish those from each other), the part after
 the last slash is considered the filename, which \strong{should} adhere to the
-restrictions listed above, and in addition should \strong{not} contain \code{:}
-\strong{nor} start with a space or a hyphen (\code{-}), while it \strong{might} contain
-the Windows-reserved terms given in the second point above.
+restrictions listed above (although it \strong{may} contain the Windows-reserved
+terms listed in the second point above), and in addition should \strong{not}
+contain \code{:} \strong{nor} start with a space or a hyphen (\code{-}).
 }
 
 These restrictions on \code{x} consider characters and words that are not allowed
 in Windows and thus would lead to an error when used to create a directory or
-file; and characters that are silently removed in Windows and thus would lead
+file; characters that are silently removed in Windows and thus would lead
 to a mismatch between the created directory and the returned path when used
-to create a directory.
+to create a directory; and characters that might give problems when used in
+the shell.
 
 \code{is_path()} allows some patterns that will not occur in real (i.e., existing)
 paths or filenames:
@@ -112,17 +113,22 @@ is_path(fs::path_wd("abcd.txt"))
 is_path(fs::path_wd("abcd.txt.gz"))
 is_path(fs::path_wd("abcd.gz"))
 
-is_path(fs::path_wd("ab:cd.txt"))
-is_path(fs::path_wd("ab|cd.txt"))
+# ':' is allowed in paths but not in filenames
+is_path(fs::path_wd("ab:cd")) # TRUE
+is_path(fs::path_wd("ab:cd.txt")) # FALSE
+
+# Other illegal characters are not allowed in either paths or filenames
+is_path(fs::path_wd("ab|cd")) # FALSE
+is_path(fs::path_wd("ab|cd.txt")) # FALSE
 
 }
 \seealso{
-\link[fs:path_math]{fs::path_math} for various operations on paths; \code{\link[fs:path_sanitize]{fs::path_sanitize()}} to
+\code{\link[fs:path_math]{fs::path_math()}} for various operations on paths; \code{\link[fs:path_sanitize]{fs::path_sanitize()}} to
 \strong{remove} invalid characters from potential paths;
 \code{\link[utils:file_test]{utils::file_test()}} and references there on file existence and permissions;
-\code{progutils::create_file_path()} to create a file path, creating the directory
-if it does not yet exist; \code{progutils::create_dir()} to create a directory if
-it does not yet exist; \code{progutils::get_file_path()} to check if a file exists
+\code{\link[progutils:create_file_path]{progutils::create_file_path()}} to create a file path, creating the directory
+if it does not yet exist; \code{\link[progutils:create_dir]{progutils::create_dir()}} to create a directory if
+it does not yet exist; \code{\link[progutils:get_file_path]{progutils::get_file_path()}} to check if a file exists
 and is a unique match to a pattern.
 
 Other collections of checks on type and length:

--- a/man/paste_quoted.Rd
+++ b/man/paste_quoted.Rd
@@ -7,7 +7,7 @@
 paste_quoted(x)
 }
 \arguments{
-\item{x}{Atomic object without dimensions to be converted to a single
+\item{x}{Dimensionless atomic object to be converted to a single
 character string.}
 }
 \value{
@@ -16,7 +16,7 @@ quotes, separated by commas. See \code{Details} on the handling of some special
 values.
 }
 \description{
-Quote elements of an atomic object without dimensions and concatenate the
+Quote elements of a dimensionless atomic object and concatenate the
 result to a single character string.
 }
 \details{
@@ -31,6 +31,9 @@ An error occurs if multiple arguments are provided because then \code{x} probabl
 was accidentally not \link[=c]{combined}. For example, the call
 \code{paste_quoted("a", "b")} will return the error \verb{unused argument ("b")}. The
 probably intended call is \code{paste_quoted(c("a", "b"))}, returning \code{"'a', 'b'"}.
+
+\code{paste_quoted()} drops \link{names} of \code{x}, which is pointed out in a
+\link{warning} if \code{x} has names.
 }
 
 \examples{
@@ -41,7 +44,7 @@ paste_quoted(c(a = 3, b = 4)) # "'3', '4'" # Warns about dropping names.
 }
 \seealso{
 \code{\link[=toString]{toString()}} which can be used instead of \code{paste(x, collapse = ", ")},
-\code{\link[=sQuote]{sQuote()}} to use fancy quotes, \code{\link[=paste0]{paste0()}}, \code{progutils::unpaste_unquote()}
+\code{\link[=sQuote]{sQuote()}} to use fancy quotes, \code{\link[=paste0]{paste0()}}, \code{\link[progutils:unpaste_unquote]{progutils::unpaste_unquote()}}
 for the approximate opposite of \code{paste_quoted()}.
 }
 \concept{functions to modify character vectors}

--- a/vignettes/design_choices.Rmd
+++ b/vignettes/design_choices.Rmd
@@ -20,7 +20,7 @@ knitr::opts_chunk$set(
 ## Introduction and notation
 This vignette explains the design choices of `checkinput`. It also shows how to
 get a named boolean vector indicating for each element of `x` if it is `TRUE` or
-`FALSE` according to `all_<func>(x)`.
+`FALSE` according to `is_<func>(x)` or `all_<func>(x)`.
 
 Text between angled brackets (`<...>`) is used to refer to text that should be
 replaced with specific text to get working code. For example, `is_<func>(x)` is
@@ -38,9 +38,11 @@ other functions. Errors **are** thrown about invalid input to arguments other
 than `x`, e.g., when values other than `TRUE` or `FALSE` are used for `allow_NA`.
 
 The default arguments make functions of `checkinput` more restrictive than the
-equivalent functions in base R (e.g., `checkinput::is_logical()` versus
-`base::is.logical()`) because the functions of `checkinput` are intended for
-argument checking where, for example, zero-length `x` is unwanted.
+equivalent functions in base R because the functions of `checkinput` are
+intended for argument checking. For example, `checkinput::is_logical()` by
+default returns `FALSE` for `logical(0)` because zero-length `x` is usually
+unwanted in function arguments, whereas `base::is.logical()` returns `TRUE` for
+`logical(0)`.
 
 ## Length of x
 By default, `is_<func>(x)` of `checkinput` only returns `TRUE` for `x` of length
@@ -52,19 +54,20 @@ return `TRUE` for zero-length `x` of the correct type. See
 for a discussion of some issues with zero-length input.
 
 ## NAs and NaNs in x
-By default, functions of `checkinput`only return `TRUE` for `x` without `NA`s
-and `NaN`s. Set
-argument `allow_NA` to `TRUE` to also return `TRUE` for `x` containing `NA`s of
-the correct type, and set argument `allow_NaN` for functions like `is_number(x)`
-and `is_natural(x)` to `TRUE` to also return `TRUE` for `x` containing `NaN`s.
+By default, functions of `checkinput` return `FALSE` for `x` containing `NA`s or
+`NaN`s. Set argument `allow_NA` to `TRUE` to return `TRUE` for `x` containing
+`NA`s of
+the correct type, and set argument `allow_NaN` in functions like `is_number(x)`
+and `is_natural(x)` to `TRUE` to return `TRUE` for `x` containing `NaN`s.
 
 ## Return
 The `is_<func>(x)` and `all_<func>(x)` functions of `checkinput` always return
 either `TRUE` or `FALSE`. To get a named boolean vector indicating for each
-element of `x` if it `TRUE` or `FALSE` according to `all_<func>(x)`, use
-`vapply(X = x, FUN.VALUE = logical(1), FUN = all_<func>, ...)` instead of
-`all_<func>(x, ...)`. For example, to check which elements of `x` are valid
-names, use `vapply(X = x, FUN.VALUE = logical(1), FUN = all_names, ...)` instead
-of `all_names(x, ...)`. The dots (`...`) indicate where to place other function
-arguments, e.g., `allow_underscores = FALSE` to change the default `TRUE` for
-`allow_underscores` to `FALSE`.
+element of `x` if it `TRUE` or `FALSE` according to `is_<func>(x)` or
+`all_<func>(x)`, use
+`vapply(X = x, FUN.VALUE = logical(1), FUN = all_<func>)` instead of
+`all_<func>(x)`. For example, to check which elements of `x` are valid
+names, use `vapply(X = x, FUN.VALUE = logical(1), FUN = all_names)` instead
+of `all_names(x)`. Other function arguments passed to `all_names()`, e.g.,
+`allow_underscores = FALSE` to change the default `TRUE` for `allow_underscores`
+to `FALSE`, should be placed behind argument `x`.

--- a/vignettes/type_coercion.Rmd
+++ b/vignettes/type_coercion.Rmd
@@ -21,8 +21,7 @@ knitr::opts_chunk$set(
 
 
 ## Introduction
-When testing vector input of length larger than one, it should be kept in mind
-that objects are converted ('coerced') to a common type when combined in a
+Objects in R are converted ('coerced') to a common type when combined in a
 vector. The type of the vector, and thus of all its components, will be the
 highest type of the components in the hierarchy `NULL` < `raw` < `logical` <
 `integer` < `double` < `complex` < `character` < `list` < `expression`, see the
@@ -50,7 +49,7 @@ logiNA_char[1]
 
 
 ## Consequences for checks
-Type coercion in a vector has as consequence that code like
+As a consequence of type coercion in a vector, code like
 `all_characters(c(x, y))` does **not** check if all elements in `x` and `y` are
 character: `x` and `y` will be coerced to the highest of their types before the
 check is performed, such that `all_characters(c(x, y))` tests if any of `x` or
@@ -58,9 +57,10 @@ check is performed, such that `all_characters(c(x, y))` tests if any of `x` or
 
 To check if all elements in `x` and `y` are character, use
 `all_characters(x) && all_characters(y)` or, to generalise more easily to more
-than two objects, `all(unlist(lapply(X = list(x, y), FUN = all_characters, ...)))`,
-where `...` indicates the position of arguments passed to `all_characters()`,
-e.g., `allow_empty = TRUE`.
+than two objects, `all(unlist(lapply(X = list(x, y), FUN = all_characters)))`.
+Other function arguments passed to `all_characters()`, e.g., `allow_empty = TRUE`
+to change the default `TRUE` for `allow_empty` to `FALSE`, should be placed
+behind argument `x`.
 
 Elements of a list can contain objects of different types but using `unlist()`
 on a list creates a vector in which all elements of the list are coerced to a


### PR DESCRIPTION
### Breaking changes
- Add dependency `progutils >= 0.0.4` to `Suggests` because it is used in the documentation.

### Bugfixes
- `is_path("C:")` would warn that filename should not contain `:`.

### Documentation
- `paste_quoted()`: document that `paste_quoted()` warns about dropping names.