### PR TITLE
checkinput 0.12.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: checkinput
 Title: Check Function Input
-Version: 0.11.0
+Version: 0.12.0
 Authors@R: 
     person("Jesse", "Alderliesten", email = "jessealderliesten@hotmail.com",
     role = c("aut", "cre"), comment = c(ORCID = "0000-0003-1132-4310"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,11 +13,8 @@ Imports:
     fs
 Suggests: 
     knitr,
-    progutils (>= 0.0.4),
     rmarkdown,
     tinytest (>= 1.4.1)
-Remotes:
-    github::JesseAlderliesten/progutils
 URL: https://github.com/JesseAlderliesten/checkinput, https://jessealderliesten.github.io/checkinput/
 BugReports: https://github.com/JesseAlderliesten/checkinput/issues
 VignetteBuilder: knitr

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# checkinput 0.12.0
+
+### Breaking changes
+- `is_path()`: add argument `require_sep` to facilitate checking filenames.
+- Remove dependency `progutils` from `Suggests` to prevent dependency conflicts
+  because `progutils` itself depends on `checkinput`.
+
+
 # checkinput 0.11.0
 
 ### Breaking changes

--- a/R/all_names.R
+++ b/R/all_names.R
@@ -22,9 +22,8 @@
 #' enforced by `all_names()`.
 #'
 #' Names that consist of only dots, or consist of two dots followed by a number,
-#' are not allowed by `all_names()` (nor by `vctrs::vec_as_names()`): they are
-#' listed as [reserved] words even though they are not recognised as
-#' syntactically invalid by [make.names()].
+#' are not allowed by `all_names()` (nor by `vctrs::vec_as_names()`) even though
+#' they are not adjusted by [make.names()]: they are listed as [reserved] words.
 #'
 #' Suspicious names are not allowed by `all_names()`. A suspicious name contains
 #' a pattern suggesting it originally was syntactically invalid and has been
@@ -52,16 +51,19 @@
 #' - adjustments to make duplicated names unique: `make.names(x, unique = TRUE)`
 #'   appends a dot followed by a number;
 #'   `vctrs::vec_as_names(x, repair = "universal")` appends three dots followed
-#'   by a number.
+#'   by a number. `make.names()` does **not** adjust the first instance of a
+#'   duplicate, whereas `vctrs::vec_as_names()` **does** adjust it:
+#'   `make.names(c("a", "a"), unique = TRUE)` returns `c("a", "a.1")`, whereas
+#'   `vctrs::vec_as_names(c("a", "a"), repair = "universal")` returns
+#'   `c("a...1", "a...2")`.
 #' - adjustments to make [reserved] words valid: `make.names()` appends a dot;
 #'   `vctrs::vec_as_names(x, repair = "universal")` prepends a dot.
 #' - adjustments to make names that did not start with a letter, nor with a dot
 #'   not followed by a number, syntactically valid: `make.names()` prepends `X`;
 #'   `vctrs::vec_as_names(x, repair = "universal")` prepends one or more dots.
-#' - adjustments to name unnamed columns: `data.frame()` uses pattern `V1`,
-#'   `V2`, `V3` if a matrix without column names is converted to a data frame,
-#'   and `read.csv(..., header = FALSE)` uses the same pattern for data without
-#'   column names; `read.csv(..., header = TRUE)` uses pattern `X`, `X.1`,
+#' - adjustments to name unnamed columns: `data.frame()` uses pattern `X1`, `X2`,
+#'   `X3`; `as.data.frame()` and `read.csv(..., header = FALSE)` use pattern
+#'   `V1`, `V2`, `V3`; `read.csv(..., header = TRUE)` uses pattern `X`, `X.1`,
 #'   `X.2`. It is **not** checked if a complete sequence of suspicious names is
 #'   present, e.g., `V3` will be flagged as suspicious even if `V1` and `V2` are
 #'   absent.
@@ -267,7 +269,7 @@ all_names <- function(x, allow_underscores = TRUE) {
       c(any(bool_onlydots), any(bool_patterndots))], collapse = ", or ")
     # note_dots will be '""' which has length 1 if none is TRUE
     if(nchar(note_dots) > 0L) {
-      note_dots <- paste0("\n(it does not recognise names that consist of ",
+      note_dots <- paste0("\n(it does not adjust names that consist of ",
                           note_dots, ")")
     }
 

--- a/R/is_natural.R
+++ b/R/is_natural.R
@@ -55,10 +55,10 @@
 #' collections of checks on type and length
 #'
 #' @seealso
-#' [progutils::are_equal()] to check for element-wise near-equality of numbers;
+#' `progutils::are_equal()` to check for element-wise near-equality of numbers;
 #' [all.equal()] to check more generally for near-equality; [identical()] to
 #' check for exact equality and [Comparison] to do so using binary operators;
-#' [match()] and [progutils::not_in()] to compare character vectors; [\R FAQ 7.31](
+#' [match()] and `progutils::not_in()` to compare character vectors; [\R FAQ 7.31](
 #' https://CRAN.R-project.org/doc/manuals/R-FAQ.html#Why-doesn_0027t-R-think-these-numbers-are-equal_003f)
 #' for background on numerical equality.
 #'

--- a/R/is_path.R
+++ b/R/is_path.R
@@ -3,6 +3,8 @@
 #' Check that `x` is a valid path, possibly containing a valid filename.
 #'
 #' @inheritParams is_logical x
+#' @param require_sep should `x` include a file separator? Ignored if `x` is
+#' `"."` or `".."`.
 #'
 #' @details
 #' `is_path()` is intended to be used to check for valid paths before creating a
@@ -28,45 +30,37 @@
 #'   terms listed in the second point above), and in addition should **not**
 #'   contain `:` **nor** start with a space or a hyphen (`-`).
 #'
-#' These restrictions on `x` consider characters and words that are not allowed
+#' These restrictions on `x` consider characters and path components that are not allowed
 #' in Windows and thus would lead to an error when used to create a directory or
 #' file; characters that are silently removed in Windows and thus would lead to
 #' a mismatch between the created directory and the returned path when used to
 #' create a directory; and characters that might give problems when used in the
 #' shell.
 #'
-#' `is_path()` allows some patterns that will not occur in real (i.e., existing)
-#' paths or filenames:
+#' `is_path()` is lenient with respect to file separators (i.e., `/` or `\\`):
+#' -  `x` does **not** have to contain any file separator if `require_sep` is
+#'   `FALSE`, such that `is_path(x, require_sep = FALSE)` can be used to check
+#'   that filenames only contain allowed characters.
+#' - `x` might contain trailing file separators, although these might be ignored
+#'   or removed in some operations (e.g., they are removed by [file.path()] and
+#'   [fs::path()]).
+#' - `x` might contain successive file separators (e.g., `//` or `\\\\`): these
+#'   should be treated by the operating system as if they were only a single
+#'   file separator.
 #'
-#' - `x` does **not** have to contain a file separator (i.e., `/` or `\\`). This
-#'   makes it possible to use `is_path()` to check that input to [fs::path()]
-#'   only contains allowed characters.
-#' - `x` does **not** have to point to an existing directory (see the previous
-#'   point).
-#' - `x` might contain repeated file separators (e.g., `//` or `\\\\`): these
-#'   will be treated as if they were only a single file separator.
-#' - `x` might contain trailing file separators, even though these might be
-#'   ignored or removed in some operations (e.g., they are removed by
-#'   [file.path()] and [fs::path()])
-#'   .
+#' `is_path()` does **not** check that the path in `x` points to an existing
+#' file or folder, **nor** that such a file or folder can be created.
+#'
 #' @returns
 #' `TRUE` or `FALSE` indicating if `x` is a valid path, possibly containing a
 #' valid filename.
 #'
 #' @section Notes on paths:
 #' The file separator is a backslash (`\`) on Windows but a forward slash (`/`)
-#' on other operating systems ([.Platform$file.sep][.Platform] gives the file
-#' separator used on the current platform).
-#'
-#' Furthermore, the backslash is used
-#' as [escape character][regex] in \R, such that backslashes need to be escaped
-#' in \R code by doubling them (use `cat(x)` to see how `x` would be printed).
-#' Thus, a check on the presence of repeated slashes and backslashes in
-#' [string][is_character()] `string` would use
-#' `grepl(pattern = "//", x = string, fixed = TRUE)` and
-#' `grepl(pattern = "\\\\", x = string, fixed = TRUE)`. The message to point out
-#' their presence would be written as `message("Repeated '/' or '\\'")` which
-#' would be printed as `Repeated '/' or '\'`.
+#' on other operating systems: [.Platform$file.sep][.Platform] gives the file
+#' separator used on the current platform. Furthermore, the backslash is used as
+#' [escape character][regex] in \R, such that backslashes need to be escaped in
+#' \R code by doubling them. Use `cat(x)` to see how `x` would be printed.
 #'
 #' @section Programming notes:
 #' The output of `tempdir()` during R cmd checks on MacOS contains duplicated
@@ -105,24 +99,25 @@
 #' collections of checks on type and length
 #'
 #' @examples
-#' is_path(getwd())
-#' is_path(fs::path_wd("abcd"))
-#' is_path(fs::path_wd("ab|cd"))
+#' is_path(getwd()) # TRUE
+#' is_path(fs::path_wd("abcd")) # TRUE
+#' is_path(fs::path_wd("ab|cd")) # FALSE, warning about '|'
 #'
-#' is_path(fs::path_wd("abcd.txt"))
-#' is_path(fs::path_wd("abcd.txt.gz"))
-#' is_path(fs::path_wd("abcd.gz"))
+#' is_path(fs::path_wd("abcd.txt")) # TRUE
+#' is_path(fs::path_wd("abcd.txt.gz")) # TRUE
+#' is_path(fs::path_wd("abcd.gz")) # TRUE
 #'
 #' # ':' is allowed in paths but not in filenames
 #' is_path(fs::path_wd("ab:cd")) # TRUE
-#' is_path(fs::path_wd("ab:cd.txt")) # FALSE
+#' is_path(fs::path_wd("ab:cd.txt")) # FALSE, warning about ':'
 #'
 #' # Other illegal characters are not allowed in either paths or filenames
-#' is_path(fs::path_wd("ab|cd")) # FALSE
-#' is_path(fs::path_wd("ab|cd.txt")) # FALSE
+#' is_path(fs::path_wd("ab|cd")) # FALSE, warning about '|'
+#' is_path(fs::path_wd("ab|cd.txt")) # FALSE, warning about '|'
 #'
 #' @export
-is_path <- function(x) {
+is_path <- function(x, require_sep = TRUE) {
+  stopifnot(is_logical(require_sep))
   arg_name <- paste_quoted(deparse1(substitute(x)))
 
   if(!is_character(x)) {
@@ -137,7 +132,7 @@ is_path <- function(x) {
   # Notes:
   # - split = c("/", "\\") does not work because that recycles 'split' along 'x'
   # - fs::path_split() does not work because it tidies the path using
-  #   fs::path_tidy() before splitting, which removes repeated slashes
+  #   fs::path_tidy() before splitting, which removes successive slashes
   # - The if-else construct is needed because strsplit() discards empty quotes
   #   in the input.
   path_comp <- unlist(strsplit(x = x, split = "/", fixed = TRUE))
@@ -180,6 +175,14 @@ is_path <- function(x) {
     path_ok <- FALSE
     warning("Components of ", arg_name,
             " should not end with ' ' or '.' (i.e., a space or a dot):\n", x)
+  }
+
+  if(require_sep && !(x %in% c(".", "..")) &&
+     !grepl(pattern = "/", x = x, fixed = TRUE) &&
+     !grepl(pattern = "\\", x = x, fixed = TRUE)) {
+    path_ok <- FALSE
+    warning(paste_quoted(deparse(substitute(x))), " should contain file",
+            " separators ('/' or '\\') if 'require_sep' is 'TRUE'):\n", x)
   }
 
   filename <- basename(x)

--- a/R/is_path.R
+++ b/R/is_path.R
@@ -86,10 +86,10 @@
 #' [fs::path_math()] for various operations on paths;
 #' [fs::path_sanitize()] to **remove** invalid characters from potential paths;
 #' [utils::file_test()] and references there on file existence and permissions;
-#' [progutils::create_file_path()] to create a file path, creating the directory
+#' `progutils::create_file_path()` to create a file path, creating the directory
 #' if it does not yet exist;
-#' [progutils::create_dir()] to create a directory if it does not yet exist;
-#' [progutils::get_file_path()] to check if a file exists and is a unique match
+#' `progutils::create_dir()` to create a directory if it does not yet exist;
+#' `progutils::get_file_path()` to check if a file exists and is a unique match
 #' to a pattern.
 #'
 #' Section 'Paths in the shell' in the vignette *Git and GitHub* of package

--- a/R/is_path.R
+++ b/R/is_path.R
@@ -12,7 +12,8 @@
 #'
 #' - `x` should be a non-empty [character string][is_character()].
 #' - `x` should **not** contain the characters `"`, `*`, `?`, `|`, `<`, `>`, nor
-#'   any of the control characters (`ASCII` octal codes 000 through 037 and 177,
+#'   any of the control characters (`[:cntrl:]`, with `ASCII` octal codes 000
+#'   through 037 and 177,
 #'   see `help("regex")`). Although `:` is allowed by `is_path()` outside a
 #'   filename, Windows will only allow colons to indicate volume names like `C:\`.
 #' - path components (i.e., parts separated by file separators `/` or `\\`)

--- a/R/paste_quoted.R
+++ b/R/paste_quoted.R
@@ -27,9 +27,10 @@
 #' [warning][warning()] if `x` has names.
 #'
 #' @seealso
-#' [toString()] which can be used instead of `paste(x, collapse = ", ")`,
-#' [sQuote()] to use fancy quotes, [paste0()], [progutils::unpaste_unquote()]
-#' for the approximate opposite of `paste_quoted()`.
+#' [toString()] which can be used instead of `paste(x, collapse = ", ")`;
+#' [sQuote()] to use fancy quotes;
+#' [paste0()];
+#' `progutils::unpaste_unquote()` for the approximate opposite of `paste_quoted()`
 #'
 #' @family functions to modify character vectors
 #'

--- a/R/paste_quoted.R
+++ b/R/paste_quoted.R
@@ -30,7 +30,8 @@
 #' [toString()] which can be used instead of `paste(x, collapse = ", ")`;
 #' [sQuote()] to use fancy quotes;
 #' [paste0()];
-#' `progutils::unpaste_unquote()` for the approximate opposite of `paste_quoted()`
+#' `progutils::unpaste_unquote()` for the approximate opposite of `paste_quoted()`;
+#' `progutils::vect_to_char()` to preserve names of numeric `x`
 #'
 #' @family functions to modify character vectors
 #'

--- a/inst/tinytest/test_all_names.R
+++ b/inst/tinytest/test_all_names.R
@@ -87,7 +87,7 @@ warn_suspicious <- "Names are suspicious: "
 warn_syntax <- "are syntactically invalid: "
 warn_undersc <- paste0("contain underscores \\(which are not allowed if",
                        " 'allow_underscores' is FALSE):\n")
-note_mknm_dots <- paste0("\n\\(it does not recognise names that consist of only",
+note_mknm_dots <- paste0("\n\\(it does not adjust names that consist of only",
                          " dots, or two dots followed by digits)")
 
 
@@ -132,6 +132,13 @@ expect_warning(
 expect_warning(
   expect_false(all_names(13)),
   pattern = "'x' is not a character vector: 13", strict = TRUE, fixed = TRUE)
+
+
+#### Test documentation ####
+expect_identical(make.names(c("...", "..3"), unique = TRUE), c("...", "..3"))
+expect_identical(make.names(c("a", "a"), unique = TRUE), c("a", "a.1"))
+expect_identical(colnames(data.frame(t(1:3))), c("X1", "X2", "X3"))
+expect_identical(colnames(as.data.frame(t(1:3))), c("V1", "V2", "V3"))
 
 
 #### Test some sets ####

--- a/inst/tinytest/test_is_path.R
+++ b/inst/tinytest/test_is_path.R
@@ -33,42 +33,58 @@ expect_warning(
 
 
 #### Tests ####
-##### Miscellaneous #####
-expect_silent(expect_true(is_path(".txt")))
-expect_silent(expect_true(is_path(".gz")))
-expect_silent(expect_true(is_path("abcd")))
-expect_silent(expect_true(is_path("abcd.gz")))
-expect_silent(expect_true(is_path("abc.tx#")))
+##### require_sep #####
+expect_warning(
+  expect_false(is_path("abcd.txt", require_sep = TRUE)),
+  pattern = "should contain file separators", strict = TRUE, fixed = TRUE)
+expect_warning(
+  expect_false(is_path(".txt", require_sep = TRUE)),
+  pattern = "should contain file separators", strict = TRUE, fixed = TRUE)
+expect_warning(
+  expect_false(is_path(".gz", require_sep = TRUE)),
+  pattern = "should contain file separators", strict = TRUE, fixed = TRUE)
+expect_warning(
+  expect_false(is_path("abcd", require_sep = TRUE)),
+  pattern = "should contain file separators", strict = TRUE, fixed = TRUE)
+expect_warning(
+  expect_false(is_path("abcd.gz", require_sep = TRUE)),
+  pattern = "should contain file separators", strict = TRUE, fixed = TRUE)
+expect_warning(
+  expect_false(is_path("abc.tx#", require_sep = TRUE)),
+  pattern = "should contain file separators", strict = TRUE, fixed = TRUE)
+
+expect_silent(expect_true(is_path("abcd.txt", require_sep = FALSE)))
+expect_silent(expect_true(is_path(".txt", require_sep = FALSE)))
+expect_silent(expect_true(is_path(".gz", require_sep = FALSE)))
+expect_silent(expect_true(is_path("abcd", require_sep = FALSE)))
+expect_silent(expect_true(is_path("abcd.gz", require_sep = FALSE)))
+expect_silent(expect_true(is_path("abc.tx#", require_sep = FALSE)))
 
 ##### Illegal characters #####
 for(illegal_char in illegal_chars) {
   expect_warning(
-    expect_false(is_path(paste0("ab", illegal_char, "cd"))),
+    expect_false(is_path(paste0("ab", illegal_char, "cd"), require_sep = FALSE)),
     pattern = "should not contain '\"', '*'", fixed = TRUE)
   expect_warning(
-    expect_false(is_path(paste0("ab", illegal_char, "cd.txt"))),
+    expect_false(is_path(paste0("ab", illegal_char, "cd.txt"), require_sep = FALSE)),
     pattern = "should not contain '\"', '*'", fixed = TRUE)
 }
 
 expect_warning(
-  expect_false(is_path("ab:cd.txt")),
-  pattern = "should not contain ':'", fixed = TRUE)
-
-expect_warning(
-  expect_false(is_path("ab:cd.txt")),
+  expect_false(is_path("ab:cd.txt", require_sep = FALSE)),
   pattern = "should not contain ':'", fixed = TRUE)
 
 # fs::path_ext_remove(filename) normalized "C:" to "C:/" leading to the
 # erroneous warning that the filename should not contain ':'.
-expect_silent(expect_true(is_path("C:")))
+expect_silent(expect_true(is_path("C:", require_sep = FALSE)))
 
 for(control_char in paste0("\005", "\025", "\035", "\177")) {
   expect_warning(
-    expect_false(is_path(paste0("ab", control_char, "cd"))),
+    expect_false(is_path(paste0("ab", control_char, "cd"), require_sep = FALSE)),
     pattern = "should not contain control characters", fixed = TRUE)
 
   expect_warning(
-    expect_false(is_path(paste0("ab", control_char, "cd.txt"))),
+    expect_false(is_path(paste0("ab", control_char, "cd.txt"), require_sep = FALSE)),
     pattern = "should not contain control characters", fixed = TRUE)
 }
 
@@ -76,7 +92,7 @@ for(control_char in paste0("\005", "\025", "\035", "\177")) {
 # These are not allowed as path components but are allowed as filename
 for(Windows_name in Windows_reserved) {
   expect_warning(
-    expect_false(is_path(Windows_name)),
+    expect_false(is_path(Windows_name, require_sep = FALSE)),
     pattern = warn_Windows_reserved, fixed = TRUE)
 
   expect_warning(
@@ -93,7 +109,7 @@ for(Windows_name in Windows_reserved) {
 # 'COM', 'COM0', 'LPT' and 'LPT0' are allowed as filename and as path component
 for(Windows_allowed in c("COM", "COM0", "LPT", "LPT0")) {
   expect_true(
-    is_path(Windows_allowed))
+    is_path(Windows_allowed, require_sep = FALSE))
 
   expect_true(
     is_path(fs::path_wd("subdir", Windows_allowed, "filename.txt")))
@@ -108,71 +124,71 @@ for(Windows_allowed in c("COM", "COM0", "LPT", "LPT0")) {
 
 ##### Spaces and dots #####
 # Path elements should not end with a space
-expect_true(is_path(fs::path("a b", "def")))
+expect_true(is_path(fs::path("a b", "def"), require_sep = FALSE))
 
-expect_true(is_path(fs::path("a  b", "def")))
+expect_true(is_path(fs::path("a  b", "def"), require_sep = FALSE))
 
 expect_warning(
-  expect_false(is_path(fs::path("ab", " ", "def"))),
+  expect_false(is_path(fs::path("ab", " ", "def"), require_sep = FALSE)),
   pattern = warn_space_dot, fixed = TRUE)
 
 expect_warning(
-  expect_false(is_path(fs::path("ab", "  ", "def"))),
+  expect_false(is_path(fs::path("ab", "  ", "def"), require_sep = FALSE)),
   pattern = warn_space_dot, fixed = TRUE)
 
 expect_warning(
-  expect_false(is_path(fs::path("ab ", "def"))),
+  expect_false(is_path(fs::path("ab ", "def"), require_sep = FALSE)),
   pattern = warn_space_dot, fixed = TRUE)
 
 expect_warning(
-  expect_false(is_path(fs::path("ab  ", "def"))),
+  expect_false(is_path(fs::path("ab  ", "def"), require_sep = FALSE)),
   pattern = warn_space_dot, fixed = TRUE)
 
 expect_warning(
-  expect_false(is_path(fs::path("ab", "def "))),
+  expect_false(is_path(fs::path("ab", "def "), require_sep = FALSE)),
   pattern = warn_space_dot, fixed = TRUE)
 
 expect_warning(
-  expect_false(is_path(fs::path("ab", "def "))),
+  expect_false(is_path(fs::path("ab", "def "), require_sep = FALSE)),
   pattern = warn_space_dot, fixed = TRUE)
 
 # "." and ".." are only allowed as first path component
-expect_true(is_path(fs::path(".", "a.b", "def")))
+expect_true(is_path(fs::path(".", "a.b", "def"), require_sep = FALSE))
 
-expect_true(is_path(fs::path("..", "a..b", "def")))
+expect_true(is_path(fs::path("..", "a..b", "def"), require_sep = FALSE))
 
 expect_warning(
-  expect_false(is_path(fs::path("ab", "..", "def"))),
+  expect_false(is_path(fs::path("ab", "..", "def"), require_sep = FALSE)),
   pattern = warn_space_dot, fixed = TRUE)
 
 expect_warning(
-  expect_false(is_path(fs::path("ab", ".", "def"))),
+  expect_false(is_path(fs::path("ab", ".", "def"), require_sep = FALSE)),
   pattern = warn_space_dot, fixed = TRUE)
 
 # Path elements should not end with a dot
 expect_warning(
-  expect_false(is_path("ab.")),
+  expect_false(is_path("ab.", require_sep = FALSE)),
   pattern = "should not end with ' ' or '.'", fixed = TRUE)
 
 expect_warning(
-  expect_false(is_path(fs::path("ab.", "def"))),
+  expect_false(is_path(fs::path("ab.", "def"), require_sep = FALSE)),
   pattern = warn_space_dot, fixed = TRUE)
 
 expect_warning(
-  expect_false(is_path(fs::path("ab..", "def"))),
+  expect_false(is_path(fs::path("ab..", "def"), require_sep = FALSE)),
   pattern = warn_space_dot, fixed = TRUE)
 
 expect_warning(
-  expect_false(is_path(fs::path("ab", "def."))),
+  expect_false(is_path(fs::path("ab", "def."), require_sep = FALSE)),
   pattern = warn_space_dot, fixed = TRUE)
 
 expect_warning(
-  expect_false(is_path(fs::path("ab", "def.."))),
+  expect_false(is_path(fs::path("ab", "def.."), require_sep = FALSE)),
   pattern = warn_space_dot, fixed = TRUE)
 
 # Filenames should not end with a space or a dot
 expect_warning(
-  expect_false(is_path("..txt")),
+  expect_false(is_path("..txt", require_sep = FALSE)),
   pattern = warn_space_dot, fixed = TRUE)
 
 expect_warning(
@@ -209,42 +225,42 @@ expect_silent(expect_true(is_path(tempdir())))
 expect_true(is_path(fs::path(tempdir(), "subdir")))
 
 
-##### Repeated file separators #####
-# Need file.path() because fs::path_wd() removes repeated file separators
+##### Successive file separators #####
+# Need file.path() because fs::path_wd() removes successive file separators
 expect_silent(
-  expect_true(is_path(file.path("subdir", "/filename.txt"))))
+  expect_true(is_path(file.path("subdir", "/filename.txt"), require_sep = FALSE)))
 
 expect_silent(
-  expect_true(is_path(file.path("subdir", "\\filename.txt"))))
+  expect_true(is_path(file.path("subdir", "\\filename.txt"), require_sep = FALSE)))
 
 expect_silent(
-  expect_true(is_path(file.path("subdir", "\\\\filename.txt"))))
+  expect_true(is_path(file.path("subdir", "\\\\filename.txt"), require_sep = FALSE)))
 
 ##### Trailing file separators #####
-# To prevent warning about repeated file separators on MacOS and Ubuntu (where
+# To prevent warning about successive file separators on MacOS and Ubuntu (where
 # the paths will end in a slash)
 path_in <- fs::path_wd("subdir", "filename.txt")
 if(endsWith(path_in, suffix = "/")) {
-  expect_true(is_path(path_in))
+  expect_true(is_path(path_in, require_sep = FALSE))
 } else {
-  expect_true(is_path(paste0(path_in, "/")))
+  expect_true(is_path(paste0(path_in, "/"), require_sep = FALSE))
 }
 
 expect_true(is_path(paste0(fs::path_wd("subdir", "filename.txt"), "\\")))
 
 ##### Non-character input #####
 expect_warning(
-  expect_false(is_path(3)),
+  expect_false(is_path(3, require_sep = FALSE)),
   pattern = "should be a non-empty, non-NA_character_ character string",
   fixed = TRUE)
 
 expect_warning(
-  expect_false(is_path(c("abc.txt", "def.html"))),
+  expect_false(is_path(c("abc.txt", "def.html"), require_sep = FALSE)),
   pattern = "should be a non-empty, non-NA_character_ character string",
   fixed = TRUE)
 
 expect_warning(
-  expect_false(is_path(NA_character_)),
+  expect_false(is_path(NA_character_, require_sep = FALSE)),
   pattern = "should be a non-empty, non-NA_character_ character string",
   fixed = TRUE)
 

--- a/man/all_names.Rd
+++ b/man/all_names.Rd
@@ -37,9 +37,8 @@ would only allow digits and unaccented Latin letters, but that is \strong{not}
 enforced by \code{all_names()}.
 
 Names that consist of only dots, or consist of two dots followed by a number,
-are not allowed by \code{all_names()} (nor by \code{vctrs::vec_as_names()}): they are
-listed as \link{reserved} words even though they are not recognised as
-syntactically invalid by \code{\link[=make.names]{make.names()}}.
+are not allowed by \code{all_names()} (nor by \code{vctrs::vec_as_names()}) even though
+they are not adjusted by \code{\link[=make.names]{make.names()}}: they are listed as \link{reserved} words.
 
 Suspicious names are not allowed by \code{all_names()}. A suspicious name contains
 a pattern suggesting it originally was syntactically invalid and has been
@@ -68,16 +67,19 @@ followed in base-\R, e.g., in the function name \code{\link[=data.frame]{data.fr
 \item adjustments to make duplicated names unique: \code{make.names(x, unique = TRUE)}
 appends a dot followed by a number;
 \code{vctrs::vec_as_names(x, repair = "universal")} appends three dots followed
-by a number.
+by a number. \code{make.names()} does \strong{not} adjust the first instance of a
+duplicate, whereas \code{vctrs::vec_as_names()} \strong{does} adjust it:
+\code{make.names(c("a", "a"), unique = TRUE)} returns \code{c("a", "a.1")}, whereas
+\code{vctrs::vec_as_names(c("a", "a"), repair = "universal")} returns
+\code{c("a...1", "a...2")}.
 \item adjustments to make \link{reserved} words valid: \code{make.names()} appends a dot;
 \code{vctrs::vec_as_names(x, repair = "universal")} prepends a dot.
 \item adjustments to make names that did not start with a letter, nor with a dot
 not followed by a number, syntactically valid: \code{make.names()} prepends \code{X};
 \code{vctrs::vec_as_names(x, repair = "universal")} prepends one or more dots.
-\item adjustments to name unnamed columns: \code{data.frame()} uses pattern \code{V1},
-\code{V2}, \code{V3} if a matrix without column names is converted to a data frame,
-and \code{read.csv(..., header = FALSE)} uses the same pattern for data without
-column names; \code{read.csv(..., header = TRUE)} uses pattern \code{X}, \code{X.1},
+\item adjustments to name unnamed columns: \code{data.frame()} uses pattern \code{X1}, \code{X2},
+\code{X3}; \code{as.data.frame()} and \code{read.csv(..., header = FALSE)} use pattern
+\code{V1}, \code{V2}, \code{V3}; \code{read.csv(..., header = TRUE)} uses pattern \code{X}, \code{X.1},
 \code{X.2}. It is \strong{not} checked if a complete sequence of suspicious names is
 present, e.g., \code{V3} will be flagged as suspicious even if \code{V1} and \code{V2} are
 absent.

--- a/man/is_natural.Rd
+++ b/man/is_natural.Rd
@@ -153,10 +153,10 @@ try(toy_fun_safe(x = 5.1, all = TRUE)) # Error: all_natural(x) is not TRUE
 
 }
 \seealso{
-\code{\link[progutils:are_equal]{progutils::are_equal()}} to check for element-wise near-equality of numbers;
+\code{progutils::are_equal()} to check for element-wise near-equality of numbers;
 \code{\link[=all.equal]{all.equal()}} to check more generally for near-equality; \code{\link[=identical]{identical()}} to
 check for exact equality and \link{Comparison} to do so using binary operators;
-\code{\link[=match]{match()}} and \code{\link[progutils:not_in]{progutils::not_in()}} to compare character vectors; \href{https://CRAN.R-project.org/doc/manuals/R-FAQ.html#Why-doesn_0027t-R-think-these-numbers-are-equal_003f}{\R FAQ 7.31}
+\code{\link[=match]{match()}} and \code{progutils::not_in()} to compare character vectors; \href{https://CRAN.R-project.org/doc/manuals/R-FAQ.html#Why-doesn_0027t-R-think-these-numbers-are-equal_003f}{\R FAQ 7.31}
 for background on numerical equality.
 
 Other collections of checks on type and length:

--- a/man/is_path.Rd
+++ b/man/is_path.Rd
@@ -25,7 +25,8 @@ directory or a file. Therefore it imposes the following restrictions:
 \itemize{
 \item \code{x} should be a non-empty \link[=is_character]{character string}.
 \item \code{x} should \strong{not} contain the characters \verb{"}, \code{*}, \verb{?}, \code{|}, \code{<}, \code{>}, nor
-any of the control characters (\code{ASCII} octal codes 000 through 037 and 177,
+any of the control characters (\verb{[:cntrl:]}, with \code{ASCII} octal codes 000
+through 037 and 177,
 see \code{help("regex")}). Although \code{:} is allowed by \code{is_path()} outside a
 filename, Windows will only allow colons to indicate volume names like \verb{C:\\}.
 \item path components (i.e., parts separated by file separators \code{/} or \verb{\\\\})

--- a/man/is_path.Rd
+++ b/man/is_path.Rd
@@ -124,10 +124,10 @@ is_path(fs::path_wd("ab|cd.txt")) # FALSE, warning about '|'
 \code{\link[fs:path_math]{fs::path_math()}} for various operations on paths;
 \code{\link[fs:path_sanitize]{fs::path_sanitize()}} to \strong{remove} invalid characters from potential paths;
 \code{\link[utils:file_test]{utils::file_test()}} and references there on file existence and permissions;
-\code{\link[progutils:create_file_path]{progutils::create_file_path()}} to create a file path, creating the directory
+\code{progutils::create_file_path()} to create a file path, creating the directory
 if it does not yet exist;
-\code{\link[progutils:create_dir]{progutils::create_dir()}} to create a directory if it does not yet exist;
-\code{\link[progutils:get_file_path]{progutils::get_file_path()}} to check if a file exists and is a unique match
+\code{progutils::create_dir()} to create a directory if it does not yet exist;
+\code{progutils::get_file_path()} to check if a file exists and is a unique match
 to a pattern.
 
 Section 'Paths in the shell' in the vignette \emph{Git and GitHub} of package

--- a/man/is_path.Rd
+++ b/man/is_path.Rd
@@ -4,10 +4,13 @@
 \alias{is_path}
 \title{Check that \code{x} is a valid path}
 \usage{
-is_path(x)
+is_path(x, require_sep = TRUE)
 }
 \arguments{
 \item{x}{object to check.}
+
+\item{require_sep}{should \code{x} include a file separator? Ignored if \code{x} is
+\code{"."} or \code{".."}.}
 }
 \value{
 \code{TRUE} or \code{FALSE} indicating if \code{x} is a valid path, possibly containing a
@@ -41,44 +44,36 @@ terms listed in the second point above), and in addition should \strong{not}
 contain \code{:} \strong{nor} start with a space or a hyphen (\code{-}).
 }
 
-These restrictions on \code{x} consider characters and words that are not allowed
+These restrictions on \code{x} consider characters and path components that are not allowed
 in Windows and thus would lead to an error when used to create a directory or
 file; characters that are silently removed in Windows and thus would lead to
 a mismatch between the created directory and the returned path when used to
 create a directory; and characters that might give problems when used in the
 shell.
 
-\code{is_path()} allows some patterns that will not occur in real (i.e., existing)
-paths or filenames:
+\code{is_path()} is lenient with respect to file separators (i.e., \code{/} or \verb{\\\\}):
 \itemize{
-\item \code{x} does \strong{not} have to contain a file separator (i.e., \code{/} or \verb{\\\\}). This
-makes it possible to use \code{is_path()} to check that input to \code{\link[fs:path]{fs::path()}}
-only contains allowed characters.
-\item \code{x} does \strong{not} have to point to an existing directory (see the previous
-point).
-\item \code{x} might contain repeated file separators (e.g., \verb{//} or \verb{\\\\\\\\}): these
-will be treated as if they were only a single file separator.
-\item \code{x} might contain trailing file separators, even though these might be
-ignored or removed in some operations (e.g., they are removed by
-\code{\link[=file.path]{file.path()}} and \code{\link[fs:path]{fs::path()}})
-.
+\item \code{x} does \strong{not} have to contain any file separator if \code{require_sep} is
+\code{FALSE}, such that \code{is_path(x, require_sep = FALSE)} can be used to check
+that filenames only contain allowed characters.
+\item \code{x} might contain trailing file separators, although these might be ignored
+or removed in some operations (e.g., they are removed by \code{\link[=file.path]{file.path()}} and
+\code{\link[fs:path]{fs::path()}}).
+\item \code{x} might contain successive file separators (e.g., \verb{//} or \verb{\\\\\\\\}): these
+should be treated by the operating system as if they were only a single
+file separator.
 }
+
+\code{is_path()} does \strong{not} check that the path in \code{x} points to an existing
+file or folder, \strong{nor} that such a file or folder can be created.
 }
 \section{Notes on paths}{
 
 The file separator is a backslash (\verb{\\}) on Windows but a forward slash (\code{/})
-on other operating systems (\link[=.Platform]{.Platform$file.sep} gives the file
-separator used on the current platform).
-
-Furthermore, the backslash is used
-as \link[=regex]{escape character} in \R, such that backslashes need to be escaped
-in \R code by doubling them (use \code{cat(x)} to see how \code{x} would be printed).
-Thus, a check on the presence of repeated slashes and backslashes in
-\link[=is_character]{string} \code{string} would use
-\code{grepl(pattern = "//", x = string, fixed = TRUE)} and
-\code{grepl(pattern = "\\\\\\\\", x = string, fixed = TRUE)}. The message to point out
-their presence would be written as \code{message("Repeated '/' or '\\\\'")} which
-would be printed as \verb{Repeated '/' or '\\'}.
+on other operating systems: \link[=.Platform]{.Platform$file.sep} gives the file
+separator used on the current platform. Furthermore, the backslash is used as
+\link[=regex]{escape character} in \R, such that backslashes need to be escaped in
+\R code by doubling them. Use \code{cat(x)} to see how \code{x} would be printed.
 }
 
 \section{Programming notes}{
@@ -107,21 +102,21 @@ from the Posix standard
 }
 
 \examples{
-is_path(getwd())
-is_path(fs::path_wd("abcd"))
-is_path(fs::path_wd("ab|cd"))
+is_path(getwd()) # TRUE
+is_path(fs::path_wd("abcd")) # TRUE
+is_path(fs::path_wd("ab|cd")) # FALSE, warning about '|'
 
-is_path(fs::path_wd("abcd.txt"))
-is_path(fs::path_wd("abcd.txt.gz"))
-is_path(fs::path_wd("abcd.gz"))
+is_path(fs::path_wd("abcd.txt")) # TRUE
+is_path(fs::path_wd("abcd.txt.gz")) # TRUE
+is_path(fs::path_wd("abcd.gz")) # TRUE
 
 # ':' is allowed in paths but not in filenames
 is_path(fs::path_wd("ab:cd")) # TRUE
-is_path(fs::path_wd("ab:cd.txt")) # FALSE
+is_path(fs::path_wd("ab:cd.txt")) # FALSE, warning about ':'
 
 # Other illegal characters are not allowed in either paths or filenames
-is_path(fs::path_wd("ab|cd")) # FALSE
-is_path(fs::path_wd("ab|cd.txt")) # FALSE
+is_path(fs::path_wd("ab|cd")) # FALSE, warning about '|'
+is_path(fs::path_wd("ab|cd.txt")) # FALSE, warning about '|'
 
 }
 \seealso{

--- a/man/paste_quoted.Rd
+++ b/man/paste_quoted.Rd
@@ -43,8 +43,9 @@ paste_quoted(c(a = 3, b = 4)) # "'3', '4'" # Warns about dropping names.
 
 }
 \seealso{
-\code{\link[=toString]{toString()}} which can be used instead of \code{paste(x, collapse = ", ")},
-\code{\link[=sQuote]{sQuote()}} to use fancy quotes, \code{\link[=paste0]{paste0()}}, \code{\link[progutils:unpaste_unquote]{progutils::unpaste_unquote()}}
-for the approximate opposite of \code{paste_quoted()}.
+\code{\link[=toString]{toString()}} which can be used instead of \code{paste(x, collapse = ", ")};
+\code{\link[=sQuote]{sQuote()}} to use fancy quotes;
+\code{\link[=paste0]{paste0()}};
+\code{progutils::unpaste_unquote()} for the approximate opposite of \code{paste_quoted()}
 }
 \concept{functions to modify character vectors}

--- a/man/paste_quoted.Rd
+++ b/man/paste_quoted.Rd
@@ -46,6 +46,7 @@ paste_quoted(c(a = 3, b = 4)) # "'3', '4'" # Warns about dropping names.
 \code{\link[=toString]{toString()}} which can be used instead of \code{paste(x, collapse = ", ")};
 \code{\link[=sQuote]{sQuote()}} to use fancy quotes;
 \code{\link[=paste0]{paste0()}};
-\code{progutils::unpaste_unquote()} for the approximate opposite of \code{paste_quoted()}
+\code{progutils::unpaste_unquote()} for the approximate opposite of \code{paste_quoted()};
+\code{progutils::vect_to_char()} to preserve names of numeric \code{x}
 }
 \concept{functions to modify character vectors}


### PR DESCRIPTION
### Breaking changes
- `is_path()`: add argument `require_sep` to facilitate checking filenames.
- Remove dependency `progutils` from `Suggests` to prevent dependency conflicts because `progutils` itself depends on `checkinput`.

