### PR TITLE
Update `GitHub Actions` workflows

### DIFF
--- a/.github/workflows/check-no-suggests.yaml
+++ b/.github/workflows/check-no-suggests.yaml
@@ -1,9 +1,5 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 
-# This workflow combines elements of check-standard.yaml and
-# check-no-suggests.yaml to check if the package functions correctly without the
-# dependencies listed in 'Suggests' which I use for documentation.
-
 # NOTE: This workflow only directly installs "hard" dependencies, i.e. Depends,
 # Imports, and LinkingTo dependencies. Notably, Suggests dependencies are never
 # installed, with the exception of knitr, rcmdcheck, rmarkdown, and tinytest.
@@ -13,18 +9,19 @@
 # Modifications:
 # - not run GHA on 'push': it should be sufficient to run R CMD check locally
 #   before pushing and run GHA on pull requests.
-# - run GHA every Saturday on 04:23 UTC: added 'schedule: - cron: "23 4 * * 6"'
-# - enable manually triggering GHA: added 'workflow_dispatch:' at 'on:' (see
-#   https://docs.github.com/en/actions/reference/workflows-and-actions and
-#   https://docs.github.com/en/actions/how-tos/manage-workflow-runs).
-# - run GHA with the currently released version of R and R version 4.1.0
-#   (miniimum version used as dependency) on macOS, Windows, and Ubuntu. In
-#   addition, run GHA with the devel-version of R on Ubuntu.
+# - run GHA every Saturday on 04:23 UTC
+# - enable manually triggering GHA
+# - run GHA with the currently released version of R and R version 4.1.0 (the
+#   minimum R version required by dependency checkinput) on macOS, Windows, and
+#   Ubuntu. In addition, run GHA with the development version of R on Ubuntu.
 # - allow 'tinytest' instead of 'testthat' because that is the package I use for
 #   the tests.
 
-# Need help debugging build failures? Start at
-# https://github.com/r-lib/actions#where-to-find-help
+# For help debugging build failures, see https://r-pkgs.org/R-CMD-check.html and
+# https://github.com/r-lib/actions#where-to-find-help. For more background,
+# including an explanation of the syntax used in this file, see
+# https://docs.github.com/en/actions/reference/workflows-and-actions and
+# https://docs.github.com/en/actions/how-tos/manage-workflow-runs.
 
 on:
   pull_request:
@@ -59,7 +56,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -67,7 +64,6 @@ jobs:
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
-          use-public-rspm: true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -3,13 +3,16 @@
 # Modifications:
 # - not run GHA on 'push': it should be sufficient to run R CMD check locally
 #   before pushing and run GHA on pull requests.
-# - run GHA every Saturday on 04:23 UTC: added 'schedule: - cron: "23 4 * * 6"'
-# - enable manually triggering GHA: added 'workflow_dispatch:' at 'on:' (see
-#   https://docs.github.com/en/actions/reference/workflows-and-actions and
-#   https://docs.github.com/en/actions/how-tos/manage-workflow-runs).
+# - run GHA every Saturday on 04:23 UTC
+# - enable manually triggering GHA
+# - run GHA with the currently released version and the development version of R
+#   on Ubuntu.
 
-# Need help debugging build failures? Start at
-# https://github.com/r-lib/actions#where-to-find-help
+# For help debugging build failures, see https://r-pkgs.org/R-CMD-check.html and
+# https://github.com/r-lib/actions#where-to-find-help. For more background,
+# including an explanation of the syntax used in this file, see
+# https://docs.github.com/en/actions/reference/workflows-and-actions and
+# https://docs.github.com/en/actions/how-tos/manage-workflow-runs.
 
 on:
   pull_request:
@@ -17,12 +20,12 @@ on:
       - cron: "23 4 * * 6" # run GHA every Saturday on 04:23 UTC
   workflow_dispatch: # to be able to manually trigger GHA
 
-name: R-CMD-check.yaml
+name: check-standard.yaml
 
 permissions: read-all
 
 jobs:
-  R-CMD-check:
+  check-standard:
     runs-on: ${{ matrix.config.os }}
 
     name: ${{ matrix.config.os }} (${{ matrix.config.r }})
@@ -31,13 +34,8 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macos-latest,   r: 'release'}
-          - {os: macos-latest,   r: '4.1.0'}
-          - {os: windows-latest, r: 'release'}
-          - {os: windows-latest, r: '4.1.0'}
           - {os: ubuntu-latest,  r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,  r: 'release'}
-          - {os: ubuntu-latest,  r: '4.1.0'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -52,7 +50,6 @@ jobs:
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
-          use-public-rspm: true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,12 +1,18 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
-# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+
+# For help debugging build failures, see https://r-pkgs.org/R-CMD-check.html and
+# https://github.com/r-lib/actions#where-to-find-help. For more background,
+# including an explanation of the syntax used in this file, see
+# https://docs.github.com/en/actions/reference/workflows-and-actions and
+# https://docs.github.com/en/actions/how-tos/manage-workflow-runs.
+
 on:
   push:
-    branches: [main, master]
+    branches: [main]
   pull_request:
   release:
     types: [published]
-  workflow_dispatch:
+  workflow_dispatch: # to be able to manually trigger GHA
 
 name: pkgdown.yaml
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -12,7 +12,8 @@ knitr::opts_chunk$set(
 
 <!-- badges: start -->
 ![](https://img.shields.io/github/r-package/v/JesseAlderliesten/checkinput?color=blue)
-[![R-CMD-check](https://github.com/JesseAlderliesten/checkinput/actions/workflows/check-no-suggests.yaml/badge.svg)](https://github.com/JesseAlderliesten/checkinput/actions/workflows/check-no-suggests.yaml)
+[![R-CMD-check](https://github.com/JesseAlderliesten/checkinput/actions/workflows/check-standard.yaml/badge.svg)](https://github.com/JesseAlderliesten/checkinput/actions/workflows/check-standard.yaml)
+[![R-CMD-check-no-suggests](https://github.com/JesseAlderliesten/checkinput/actions/workflows/check-no-suggests.yaml/badge.svg)](https://github.com/JesseAlderliesten/checkinput/actions/workflows/check-no-suggests.yaml)
 <!-- badges: end -->
 
 
@@ -144,15 +145,15 @@ functions in similar packages that require a different function to include these
 special values. Nevertheless, the following similar packages are worth looking
 into:
 
-- [arkhe](https://CRAN.R-project.org/package=arkhe): tools for cleaning
+- [`arkhe`](https://CRAN.R-project.org/package=arkhe): tools for cleaning
   rectangular data.
-- [assertable](https://CRAN.R-project.org/package=assertable): verbose
+- [`assertable`](https://CRAN.R-project.org/package=assertable): verbose
   assertions for tabular data (data.frames and data.tables).
-- [assertthat](https://CRAN.R-project.org/package=assertthat): easy pre and post
+- [`assertthat`](https://CRAN.R-project.org/package=assertthat): easy pre and post
   assertions.
-- [checkmate](https://CRAN.R-project.org/package=checkmate): fast and versatile
+- [`checkmate`](https://CRAN.R-project.org/package=checkmate): fast and versatile
   argument checks
-- [chk](https://CRAN.R-project.org/package=chk): check user-supplied function
+- [`chk`](https://CRAN.R-project.org/package=chk): check user-supplied function
   arguments
-- [erify](https://CRAN.R-project.org/package=erify): check arguments and
+- [`erify`](https://CRAN.R-project.org/package=erify): check arguments and
   generate readable error messages

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 <!-- badges: start -->
 
 ![](https://img.shields.io/github/r-package/v/JesseAlderliesten/checkinput?color=blue)
-[![R-CMD-check](https://github.com/JesseAlderliesten/checkinput/actions/workflows/check-no-suggests.yaml/badge.svg)](https://github.com/JesseAlderliesten/checkinput/actions/workflows/check-no-suggests.yaml)
+[![R-CMD-check](https://github.com/JesseAlderliesten/checkinput/actions/workflows/check-standard.yaml/badge.svg)](https://github.com/JesseAlderliesten/checkinput/actions/workflows/check-standard.yaml)
+[![R-CMD-check-no-suggests](https://github.com/JesseAlderliesten/checkinput/actions/workflows/check-no-suggests.yaml/badge.svg)](https://github.com/JesseAlderliesten/checkinput/actions/workflows/check-no-suggests.yaml)
 <!-- badges: end -->
 
 # checkinput
@@ -142,8 +143,7 @@ License](LICENSE.md).
     To cite package 'checkinput' in publications use:
 
       Alderliesten J (2026). _checkinput: Check Function Input_. R package
-      version 1.0.0, commit a3f2c67ac7c2905a810ce917edd4502de6c7f5bd,
-      <https://github.com/JesseAlderliesten/checkinput>.
+      version 1.0.1, <https://github.com/JesseAlderliesten/checkinput>.
 
     A BibTeX entry for LaTeX users is
 
@@ -151,7 +151,7 @@ License](LICENSE.md).
         title = {checkinput: Check Function Input},
         author = {Jesse Alderliesten},
         year = {2026},
-        note = {R package version 1.0.0, commit a3f2c67ac7c2905a810ce917edd4502de6c7f5bd},
+        note = {R package version 1.0.1},
         url = {https://github.com/JesseAlderliesten/checkinput},
       }
 
@@ -163,15 +163,15 @@ flexible than functions in similar packages that require a different
 function to include these special values. Nevertheless, the following
 similar packages are worth looking into:
 
-- [arkhe](https://CRAN.R-project.org/package=arkhe): tools for cleaning
-  rectangular data.
-- [assertable](https://CRAN.R-project.org/package=assertable): verbose
+- [`arkhe`](https://CRAN.R-project.org/package=arkhe): tools for
+  cleaning rectangular data.
+- [`assertable`](https://CRAN.R-project.org/package=assertable): verbose
   assertions for tabular data (data.frames and data.tables).
-- [assertthat](https://CRAN.R-project.org/package=assertthat): easy pre
-  and post assertions.
-- [checkmate](https://CRAN.R-project.org/package=checkmate): fast and
+- [`assertthat`](https://CRAN.R-project.org/package=assertthat): easy
+  pre and post assertions.
+- [`checkmate`](https://CRAN.R-project.org/package=checkmate): fast and
   versatile argument checks
-- [chk](https://CRAN.R-project.org/package=chk): check user-supplied
+- [`chk`](https://CRAN.R-project.org/package=chk): check user-supplied
   function arguments
-- [erify](https://CRAN.R-project.org/package=erify): check arguments and
-  generate readable error messages
+- [`erify`](https://CRAN.R-project.org/package=erify): check arguments
+  and generate readable error messages


### PR DESCRIPTION
Update `GitHub Actions` workflows to reflect updates to the `r-lib/actions` source. Replace `R-CMD-check` GitHub Actions workflow by separate `check-no-suggests` and `check-standard` workflows. Add some links to their documentation. Update `README` badges to reflect updates to GitHub Action workflows. Stylistic updates.