### PR TITLE
checkinput 1.1.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: checkinput
 Title: Check Function Input
-Version: 1.0.1
+Version: 1.1.0
 Authors@R: 
     person("Jesse", "Alderliesten", , "jessealderliesten@hotmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-1132-4310"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ BugReports: https://github.com/JesseAlderliesten/checkinput/issues
 Depends: 
     R (>= 4.1.0)
 Imports: 
-    fs
+    fs (>= 1.2.4)
 Suggests: 
     knitr,
     rmarkdown,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# checkinput 1.1.0
+
+### Breaking changes
+- Dependency `fs`: require minimum version `1.2.4` because `path_wd()` is used.
+
+### Documentation
+- Stylistic updates, adding more links to `is_path()`.
+
+
 # checkinput 1.0.1
 
 ### Documentation

--- a/R/all_names.R
+++ b/R/all_names.R
@@ -15,7 +15,7 @@
 #'
 #' [Syntactically valid][make.names()] names only consist of letters, numbers,
 #' dots and underscores; start with a letter, or with a dot not followed by a
-#' number; and are not [reserved] words such as [`for`] or any of the [`NA`]s. The
+#' number; and are not [reserved] words such as [`for`] or [`NA`]. The
 #' definition of **letter** depends on the current [locale][locales]. A
 #' conservative check for names that are syntactically valid on all locales
 #' would only allow digits and unaccented Latin letters, but that is **not**

--- a/R/is_number.R
+++ b/R/is_number.R
@@ -20,7 +20,7 @@
 #'   is `TRUE`.
 #' - for `-Inf` and `Inf` if it has the correct sign
 #' - for `NA_integer_` and `NA_real_` if `allow_NA` is `TRUE` (even then they
-#'   return `FALSE` for `NA_complex_` because that has mode is `complex` instead
+#'   return `FALSE` for `NA_complex_` because that has mode `complex` instead
 #'   of `numeric`)
 #' - for [`NaN`] (which has [mode] `numeric`, despite meaning 'not a number') if
 #'   `allow_NaN` is `TRUE`.

--- a/R/is_path.R
+++ b/R/is_path.R
@@ -89,15 +89,22 @@
 #'   [Wikipedia](https://en.wikipedia.org/wiki/Comparison_of_file_systems#Limits)
 #'
 #' @seealso
-#' [fs::path_math()] for various operations on paths;
+#' [fs::path()] to construct file paths in a platform-independent way,
+#' [fs::path_abs()] to make paths absolute and normalised, and [fs::path_math()]
+#' for more operations on paths;
 #' [fs::path_sanitize()] to **remove** invalid characters from potential paths;
 #' [utils::file_test()] and references there on checking file existence and
 #' permissions;
-#' `progutils::create_file_path()` to create a file path, creating the directory
-#' if it does not yet exist;
-#' `progutils::create_dir()` to create a directory if it does not yet exist;
-#' `progutils::get_file_path()` to check if a file exists and is a unique match
-#' to a pattern.
+#' [`progutils::create_file_path()`](https://jessealderliesten.github.io/progutils/reference/create_file_path.html)
+#' to create a file path, creating the directory if it does not yet exist;
+#' [`progutils::create_dir()`](https://jessealderliesten.github.io/progutils/reference/create_dir.html)
+#' to create a directory if it does not yet exist;
+#' [`progutils::get_file_path()`](https://jessealderliesten.github.io/progutils/reference/get_file_path.html)
+#' to check if a file exists and is a unique match to a pattern, and
+#' [fs::file_exists()] and [list.files()] (which **includes** directories) to do
+#' so without checking they are a unique match to a pattern;
+#' [file.info()] and [file.access()] to extract information about files or
+#' directories;
 #'
 #' Section 'Paths in the shell' in the vignette *Git and GitHub* of package
 #' `checkrpkgs` (`vignette("git_github", package = "checkrpkgs")`) on paths and

--- a/R/paste_quoted.R
+++ b/R/paste_quoted.R
@@ -1,13 +1,18 @@
 #' Quote and concatenate `x` to a string
 #'
-#' Quote elements of a dimensionless atomic object and concatenate the result to
-#' a single character string.
+#' Quote elements of a a vector and concatenate the result to a single character
+#' string.
 #'
 #' @details
-#' `NULL` is returned as `"'NULL'"`, other zero-length objects are returned as
-#' `"'<class>(0)'"` (e.g., `"'logical(0)'"`), `""` as `'""'`, logical `NA` as
-#' `"'NA'"`, and non-logical `NA`s as `"'NA_<class>_'"` (e.g., `"'NA_real_'"`;
-#' for [factors][factor] this is `"'NA_character_'"`).
+#' Some values are handled specially to print clearer:
+#'
+#' - `NULL` is returned as `"'NULL'"`
+#' - non-`NULL` zero-length objects are returned as `"'<class>(0)'"` (e.g.,
+#'   `"'logical(0)'"`)
+#' - `""` is returned as `'""'`
+#' - logical `NA` is returned as `"'NA'"`
+#' - non-logical `NA` is returned as `"'NA_<class>_'"` (e.g., `"'NA_real_'"`;
+#'   for [factors][factor] this is `"'NA_character_'"`).
 #'
 #' @param x Dimensionless atomic object to be converted to a single character
 #' string.
@@ -31,7 +36,7 @@
 #' [toString()] which can be used instead of `paste(x, collapse = ", ")`;
 #' [`Quotes`] and [sQuote()] for documentation on quotes;
 #' [paste0()];
-#' `progutils::unpaste_unquote()` for the approximate opposite of `paste_quoted()`;
+#' `progutils::unpaste_unquote()` for the approximate reverse of `paste_quoted()`;
 #' `progutils::vect_to_char()` to preserve names of numeric `x`
 #'
 #' @family functions to modify character vectors

--- a/R/paste_quoted.R
+++ b/R/paste_quoted.R
@@ -33,7 +33,7 @@
 #' these warnings.
 #'
 #' @seealso
-#' [toString()] which can be used instead of `paste(x, collapse = ", ")`;
+#' [toString()] which is shorthand for `paste(x, collapse = ", ")`;
 #' [`Quotes`] and [sQuote()] for documentation on quotes;
 #' [paste0()];
 #' `progutils::unpaste_unquote()` for the approximate reverse of `paste_quoted()`;

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ License](LICENSE.md).
     To cite package 'checkinput' in publications use:
 
       Alderliesten J (2026). _checkinput: Check Function Input_. R package
-      version 1.0.1, <https://github.com/JesseAlderliesten/checkinput>.
+      version 1.1.0, <https://github.com/JesseAlderliesten/checkinput>.
 
     A BibTeX entry for LaTeX users is
 
@@ -151,7 +151,7 @@ License](LICENSE.md).
         title = {checkinput: Check Function Input},
         author = {Jesse Alderliesten},
         year = {2026},
-        note = {R package version 1.0.1},
+        note = {R package version 1.1.0},
         url = {https://github.com/JesseAlderliesten/checkinput},
       }
 

--- a/man/all_names.Rd
+++ b/man/all_names.Rd
@@ -30,7 +30,7 @@ invalid names might, by definition, give undocumented results.
 
 \link[=make.names]{Syntactically valid} names only consist of letters, numbers,
 dots and underscores; start with a letter, or with a dot not followed by a
-number; and are not \link{reserved} words such as \code{\link{for}} or any of the \code{\link{NA}}s. The
+number; and are not \link{reserved} words such as \code{\link{for}} or \code{\link{NA}}. The
 definition of \strong{letter} depends on the current \link[=locales]{locale}. A
 conservative check for names that are syntactically valid on all locales
 would only allow digits and unaccented Latin letters, but that is \strong{not}

--- a/man/is_number.Rd
+++ b/man/is_number.Rd
@@ -60,7 +60,7 @@ All these functions return \code{TRUE}:
 is \code{TRUE}.
 \item for \code{-Inf} and \code{Inf} if it has the correct sign
 \item for \code{NA_integer_} and \code{NA_real_} if \code{allow_NA} is \code{TRUE} (even then they
-return \code{FALSE} for \code{NA_complex_} because that has mode is \code{complex} instead
+return \code{FALSE} for \code{NA_complex_} because that has mode \code{complex} instead
 of \code{numeric})
 \item for \code{\link{NaN}} (which has \link{mode} \code{numeric}, despite meaning 'not a number') if
 \code{allow_NaN} is \code{TRUE}.

--- a/man/is_path.Rd
+++ b/man/is_path.Rd
@@ -127,15 +127,22 @@ is_path(fs::path_wd("ab|cd.txt")) # FALSE, warning about '|'
 
 }
 \seealso{
-\code{\link[fs:path_math]{fs::path_math()}} for various operations on paths;
+\code{\link[fs:path]{fs::path()}} to construct file paths in a platform-independent way,
+\code{\link[fs:path_abs]{fs::path_abs()}} to make paths absolute and normalised, and \code{\link[fs:path_math]{fs::path_math()}}
+for more operations on paths;
 \code{\link[fs:path_sanitize]{fs::path_sanitize()}} to \strong{remove} invalid characters from potential paths;
 \code{\link[utils:file_test]{utils::file_test()}} and references there on checking file existence and
 permissions;
-\code{progutils::create_file_path()} to create a file path, creating the directory
-if it does not yet exist;
-\code{progutils::create_dir()} to create a directory if it does not yet exist;
-\code{progutils::get_file_path()} to check if a file exists and is a unique match
-to a pattern.
+\href{https://jessealderliesten.github.io/progutils/reference/create_file_path.html}{\code{progutils::create_file_path()}}
+to create a file path, creating the directory if it does not yet exist;
+\href{https://jessealderliesten.github.io/progutils/reference/create_dir.html}{\code{progutils::create_dir()}}
+to create a directory if it does not yet exist;
+\href{https://jessealderliesten.github.io/progutils/reference/get_file_path.html}{\code{progutils::get_file_path()}}
+to check if a file exists and is a unique match to a pattern, and
+\code{\link[fs:file_exists]{fs::file_exists()}} and \code{\link[=list.files]{list.files()}} (which \strong{includes} directories) to do
+so without checking they are a unique match to a pattern;
+\code{\link[=file.info]{file.info()}} and \code{\link[=file.access]{file.access()}} to extract information about files or
+directories;
 
 Section 'Paths in the shell' in the vignette \emph{Git and GitHub} of package
 \code{checkrpkgs} (\code{vignette("git_github", package = "checkrpkgs")}) on paths and

--- a/man/paste_quoted.Rd
+++ b/man/paste_quoted.Rd
@@ -16,14 +16,20 @@ quotes, separated by commas. See \code{Details} on the handling of some special
 values.
 }
 \description{
-Quote elements of a dimensionless atomic object and concatenate the result to
-a single character string.
+Quote elements of a a vector and concatenate the result to a single character
+string.
 }
 \details{
-\code{NULL} is returned as \code{"'NULL'"}, other zero-length objects are returned as
-\code{"'<class>(0)'"} (e.g., \code{"'logical(0)'"}), \code{""} as \code{'""'}, logical \code{NA} as
-\code{"'NA'"}, and non-logical \code{NA}s as \code{"'NA_<class>_'"} (e.g., \code{"'NA_real_'"};
+Some values are handled specially to print clearer:
+\itemize{
+\item \code{NULL} is returned as \code{"'NULL'"}
+\item non-\code{NULL} zero-length objects are returned as \code{"'<class>(0)'"} (e.g.,
+\code{"'logical(0)'"})
+\item \code{""} is returned as \code{'""'}
+\item logical \code{NA} is returned as \code{"'NA'"}
+\item non-logical \code{NA} is returned as \code{"'NA_<class>_'"} (e.g., \code{"'NA_real_'"};
 for \link[=factor]{factors} this is \code{"'NA_character_'"}).
+}
 }
 \section{Notes}{
 
@@ -47,7 +53,7 @@ paste_quoted(c(a = 3, b = 4)) # "'3', '4'" # Warns about dropping names.
 \code{\link[=toString]{toString()}} which can be used instead of \code{paste(x, collapse = ", ")};
 \code{\link{Quotes}} and \code{\link[=sQuote]{sQuote()}} for documentation on quotes;
 \code{\link[=paste0]{paste0()}};
-\code{progutils::unpaste_unquote()} for the approximate opposite of \code{paste_quoted()};
+\code{progutils::unpaste_unquote()} for the approximate reverse of \code{paste_quoted()};
 \code{progutils::vect_to_char()} to preserve names of numeric \code{x}
 }
 \concept{functions to modify character vectors}

--- a/man/paste_quoted.Rd
+++ b/man/paste_quoted.Rd
@@ -50,7 +50,7 @@ paste_quoted(c(a = 3, b = 4)) # "'3', '4'" # Warns about dropping names.
 
 }
 \seealso{
-\code{\link[=toString]{toString()}} which can be used instead of \code{paste(x, collapse = ", ")};
+\code{\link[=toString]{toString()}} which is shorthand for \code{paste(x, collapse = ", ")};
 \code{\link{Quotes}} and \code{\link[=sQuote]{sQuote()}} for documentation on quotes;
 \code{\link[=paste0]{paste0()}};
 \code{progutils::unpaste_unquote()} for the approximate reverse of \code{paste_quoted()};


### PR DESCRIPTION
### Breaking changes
- Dependency `fs`: require minimum version `1.2.4` because `path_wd()` is used.

### Documentation
- Stylistic updates, adding more links to `is_path()`.