### PR TITLE
checkinput 1.2.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: checkinput
 Title: Check Function Input
-Version: 1.1.0
+Version: 1.2.0
 Authors@R: 
     person("Jesse", "Alderliesten", , "jessealderliesten@hotmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-1132-4310"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# checkinput 1.2.0
+
+### Breaking changes
+- `is_path()`: colons are only allowed in the first path component. File names
+  should not end with a slash or backslash. Paths should end in a slash if they
+  only are volume names. Relative paths like `"D:ab/c"` are not allowed.
+
+
 # checkinput 1.1.0
 
 ### Breaking changes

--- a/R/is_path.R
+++ b/R/is_path.R
@@ -30,7 +30,8 @@
 #'   the last slash is considered the filename, which **should** adhere to the
 #'   restrictions listed above (although it **may** contain the Windows-reserved
 #'   terms listed above), and in addition should **not**
-#'   contain a colon (`:`) **nor** start with a space or a hyphen (`-`).
+#'   contain a colon (`:`), **not** start with a space or a hyphen (`-`),
+#'   **nor** end with a slash or backslash.
 #'
 #' These restrictions on `x` consider characters and path components that are
 #' **not** allowed
@@ -41,11 +42,13 @@
 #' shell.
 #'
 #' `is_path()` is lenient with respect to file separators (i.e., `/` or `\\`):
+#'
 #' -  `x` does **not** have to contain any file separator if `require_sep` is
 #'   `FALSE`, such that `is_path(x, require_sep = FALSE)` can be used to check
-#'   that filenames only contain allowed characters (given that `x` contains a
+#'   that filename `x` only contains allowed characters (given that it ends in a
 #'   file extension).
-#' - `x` might contain trailing file separators, although these might be ignored
+#' - `x` might contain trailing file separators if it does **not** end in a
+#'   file extension, although these trailing file separators might be ignored
 #'   or removed in some operations (e.g., they are removed by [file.path()] and
 #'   [fs::path()]).
 #' - `x` might contain successive file separators (e.g., `//` or `\\\\`): these
@@ -217,6 +220,12 @@ is_path <- function(x, require_sep = TRUE) {
     grepl(pattern = "\\.([^.]+)$", x = filename, perl = TRUE)
 
   if(has_file_ext) {
+    if(endsWith(x, suffix = "/") || endsWith(x, suffix = "\\")) {
+      path_ok <- FALSE
+      warning("The filename (", paste_quoted(filename), ") in ", arg_name,
+              " should not end with a slash or backslash:\n", x)
+    }
+
     if(length(filename_no_ext) == 0L || !nzchar(filename_no_ext)) {
       path_ok <- FALSE
       warning("filename without extension (", paste_quoted(filename_no_ext),

--- a/R/is_path.R
+++ b/R/is_path.R
@@ -89,22 +89,24 @@
 #'   [Wikipedia](https://en.wikipedia.org/wiki/Comparison_of_file_systems#Limits)
 #'
 #' @seealso
-#' [fs::path()] to construct file paths in a platform-independent way,
-#' [fs::path_abs()] to make paths absolute and normalised, and [fs::path_math()]
-#' for more operations on paths;
-#' [fs::path_sanitize()] to **remove** invalid characters from potential paths;
-#' [utils::file_test()] and references there on checking file existence and
-#' permissions;
+#' [fs::path()] to construct file paths in a platform-independent way;
+#' [fs::path_abs()] to make paths absolute and normalised;
+#' [fs::path_math()] for even more operations on paths;
+#' [fs::path_sanitize()] to **remove** invalid characters from potential paths
+#'
 #' [`progutils::create_file_path()`](https://jessealderliesten.github.io/progutils/reference/create_file_path.html)
 #' to create a file path, creating the directory if it does not yet exist;
 #' [`progutils::create_dir()`](https://jessealderliesten.github.io/progutils/reference/create_dir.html)
-#' to create a directory if it does not yet exist;
+#' to create a directory if it does not yet exist
+#'
 #' [`progutils::get_file_path()`](https://jessealderliesten.github.io/progutils/reference/get_file_path.html)
 #' to check if a file exists and is a unique match to a pattern, and
 #' [fs::file_exists()] and [list.files()] (which **includes** directories) to do
 #' so without checking they are a unique match to a pattern;
+#' [utils::file_test()] and references there on checking file existence and
+#' permissions;
 #' [file.info()] and [file.access()] to extract information about files or
-#' directories;
+#' directories
 #'
 #' Section 'Paths in the shell' in the vignette *Git and GitHub* of package
 #' `checkrpkgs` (`vignette("git_github", package = "checkrpkgs")`) on paths and
@@ -146,18 +148,12 @@ is_path <- function(x, require_sep = TRUE) {
   path_ok <- TRUE
 
   # Notes:
-  # - split = c("/", "\\") does not work because that recycles 'split' along 'x'
-  # - fs::path_split() does not work because it tidies the path using
-  #   fs::path_tidy() before splitting, which removes successive slashes
-  # - The if-else construct is needed because strsplit() discards empty quotes
-  #   in the input.
-  path_comp <- unlist(strsplit(x = x, split = "/", fixed = TRUE))
-  if(any(!nzchar(path_comp))) {
-    path_comp <- c(unlist(strsplit(x = path_comp, split = "\\", fixed = TRUE)),
-                   "")
-  } else {
-    path_comp <- unlist(strsplit(x = path_comp, split = "\\", fixed = TRUE))
-  }
+  # - base::split(x = x, f = c("/", "\\")) does not work because that recycles
+  #   'split' along 'x'
+  # - fs::path_split() removes successive and trailing slashes before splitting.
+  #   That is not a problem because such slashes are allowed by 'is_path()'
+  #   because the operating system should ignore those anyway.
+  path_comp <- fs::path_split(path = x)[[1]]
 
   if(grepl(pattern = '["*?|<>]', x = x)) {
     path_ok <- FALSE

--- a/R/is_path.R
+++ b/R/is_path.R
@@ -14,9 +14,9 @@
 #' - `x` should **not** contain the characters `"`, `*`, `?`, `|`, `<`, `>`, nor
 #'   any of the control characters (`[:cntrl:]`, with `ASCII` octal codes 000
 #'   through 037 and 177,
-#'   see `help("regex")`). Although colons (`:`) outside a filename are allowed
-#'   by `is_path()`, Windows will only allow colons to indicate volume names
-#'   like `C:\`.
+#'   see `help("regex")`).
+#' - `x` should **not** contain colons (`:`) after the first path component
+#'   (Windows only allows colons to indicate volume names like `C:\`).
 #' - path components (i.e., parts separated by file separators `/` or `\\`)
 #'   should **not** be the Windows-reserved terms `CON`, `PRN`, `AUX`, `NUL`,
 #'   `COM<non-zero digit>`, `LPT<non-zero digit>`, case-insensitive variants of
@@ -122,8 +122,9 @@
 #' is_path(fs::path_wd("abcd.txt.gz")) # TRUE
 #' is_path(fs::path_wd("abcd.gz")) # TRUE
 #'
-#' # ':' is allowed in paths but not in filenames
-#' is_path(fs::path_wd("ab:cd")) # TRUE
+#' # ':' is only allowed in the first path component
+#' is_path("D:/") # TRUE
+#' is_path(fs::path_wd("ab:cd")) # FALSE, warning about ':'
 #' is_path(fs::path_wd("ab:cd.txt")) # FALSE, warning about ':'
 #'
 #' # Other illegal characters are not allowed in either paths or filenames
@@ -178,6 +179,15 @@ is_path <- function(x, require_sep = TRUE) {
     warning("Components of ", arg_name,
             " should not contain Windows-reserved names (",
             paste_quoted(reserved_comp), "):\n", x)
+  }
+
+  ind_colon <- grep(pattern = ":", x = path_comp, fixed = TRUE)
+  # colons are allowed in the first path component
+  if(any(ind_colon > 1L)) {
+    path_ok <- FALSE
+    ind_colon <- ind_colon[ind_colon > 1L]
+    warning("Components ", paste(ind_colon, collapse = " and "), " of ",
+            arg_name, " should not contain ':':\n", x)
   }
 
   bool_path_dot <- endsWith(x = path_comp, suffix = ".")

--- a/R/is_path.R
+++ b/R/is_path.R
@@ -11,6 +11,10 @@
 #' directory or a file. Therefore it imposes the following restrictions:
 #'
 #' - `x` should be a non-empty [character string][is_character()]
+#' - `x` should end in a slash if it is only a volume name: `C:\`, **not** `C:`.
+#' - `x` should **not** be a relative path of the form `D:path` or `d:path`:
+#'   such paths are not guaranteed to work with functions like `file.create()`.
+#'   Use `D:./path` or `d:./path` instead.
 #' - `x` should **not** contain the characters `"`, `*`, `?`, `|`, `<`, `>`, nor
 #'   any of the control characters (`[:cntrl:]`, with `ASCII` octal codes 000
 #'   through 037 and 177,
@@ -139,7 +143,8 @@
 #' @export
 is_path <- function(x, require_sep = TRUE) {
   stopifnot(is_logical(require_sep))
-  arg_name <- paste_quoted(deparse1(substitute(x)))
+  arg_deparsed <- deparse1(substitute(x))
+  arg_name <- paste_quoted(arg_deparsed)
 
   if(!is_character(x)) {
     warning(arg_name,
@@ -149,6 +154,20 @@ is_path <- function(x, require_sep = TRUE) {
   }
 
   path_ok <- TRUE
+
+  # Path should end in a slash if it is only a volume name.
+  if(grepl(pattern = "^.:$", x = x)) {
+    path_ok <- FALSE
+    warning(arg_name, "(", x, ") should end in a slash if it is only a volume",
+            "name:\n", fs::path(x))
+  }
+
+  # Path with a colon as second character should be followed by a character that
+  # is not a path separator
+  if(grepl(pattern = "^.:[^/\\]+", x = x)) {
+    path_ok <- FALSE
+    warning("The form of relative path ", arg_name, " is invalid:\n", x)
+  }
 
   # Notes:
   # - base::split(x = x, f = c("/", "\\")) does not work because that recycles

--- a/README.Rmd
+++ b/README.Rmd
@@ -38,7 +38,7 @@ remotes::install_github(repo = "JesseAlderliesten/checkinput",
 ```
 
 For more information about installing and configuring R and RStudio, see my
-package [checkrpkgs](https://jessealderliesten.github.io/checkrpkgs/).
+package [`checkrpkgs`](https://jessealderliesten.github.io/checkrpkgs/).
 
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ remotes::install_github(repo = "JesseAlderliesten/checkinput",
 
 For more information about installing and configuring R and RStudio, see
 my package
-[checkrpkgs](https://jessealderliesten.github.io/checkrpkgs/).
+[`checkrpkgs`](https://jessealderliesten.github.io/checkrpkgs/).
 
 ## Example
 
@@ -143,7 +143,7 @@ License](LICENSE.md).
     To cite package 'checkinput' in publications use:
 
       Alderliesten J (2026). _checkinput: Check Function Input_. R package
-      version 1.1.0, <https://github.com/JesseAlderliesten/checkinput>.
+      version 1.2.0, <https://github.com/JesseAlderliesten/checkinput>.
 
     A BibTeX entry for LaTeX users is
 
@@ -151,7 +151,7 @@ License](LICENSE.md).
         title = {checkinput: Check Function Input},
         author = {Jesse Alderliesten},
         year = {2026},
-        note = {R package version 1.1.0},
+        note = {R package version 1.2.0},
         url = {https://github.com/JesseAlderliesten/checkinput},
       }
 

--- a/inst/tinytest/test_is_path.R
+++ b/inst/tinytest/test_is_path.R
@@ -18,8 +18,10 @@ expect_true(is_path(fs::path_wd("abcd.txt")))
 expect_true(is_path(fs::path_wd("abcd.txt.gz")))
 expect_true(is_path(fs::path_wd("abcd.gz")))
 
-expect_silent(
-  expect_true(is_path(fs::path_wd("ab:cd"))))
+expect_silent(expect_true(is_path("D:/")))
+expect_warning(
+  expect_false(is_path(fs::path_wd("ab:cd"))),
+  pattern = "should not contain ':'", fixed = TRUE)
 expect_warning(
   expect_false(is_path(fs::path_wd("ab:cd.txt"))),
   pattern = "should not contain ':'", fixed = TRUE)
@@ -70,8 +72,32 @@ for(illegal_char in illegal_chars) {
     pattern = "should not contain '\"', '*'", fixed = TRUE)
 }
 
+expect_silent(expect_true(is_path("ab:cd/mno/file.txt", require_sep = FALSE)))
+
 expect_warning(
-  expect_false(is_path("ab:cd.txt", require_sep = FALSE)),
+  expect_false(is_path("abcd/ef:gh/file.txt", require_sep = FALSE)),
+  pattern = "should not contain ':'", fixed = TRUE)
+
+expect_warning(
+  expect_false(is_path("abcd/efgh/fi:le.txt", require_sep = FALSE)),
+  pattern = "should not contain ':'", fixed = TRUE)
+
+expect_silent(expect_true(is_path("ab:cd/efgh", require_sep = FALSE)))
+
+expect_warning(
+  expect_false(is_path("abcd/ef:gh", require_sep = FALSE)),
+  pattern = "should not contain ':'", fixed = TRUE)
+
+expect_silent(expect_true(is_path("ab:cd/file.txt", require_sep = FALSE)))
+
+expect_warning(
+  expect_false(is_path("abcd/fi:le.txt", require_sep = FALSE)),
+  pattern = "should not contain ':'", fixed = TRUE)
+
+expect_silent(expect_true(is_path("ab:cd", require_sep = FALSE)))
+
+expect_warning(
+  expect_false(is_path("fi:le.txt", require_sep = FALSE)),
   pattern = "should not contain ':'", fixed = TRUE)
 
 # fs::path_ext_remove(filename) normalized "C:" to "C:/" leading to the

--- a/inst/tinytest/test_is_path.R
+++ b/inst/tinytest/test_is_path.R
@@ -62,6 +62,33 @@ expect_silent(expect_true(is_path("abcd", require_sep = FALSE)))
 expect_silent(expect_true(is_path("abcd.gz", require_sep = FALSE)))
 expect_silent(expect_true(is_path("abc.tx#", require_sep = FALSE)))
 
+##### Relative paths #####
+# See also section 'Illegal characters' below
+expect_silent(expect_true(is_path("D:/")))
+expect_silent(expect_true(is_path("D:/ab")))
+expect_silent(expect_true(is_path("D:\\")))
+expect_silent(expect_true(is_path("D:\\ab")))
+expect_silent(expect_true(is_path("d:/")))
+expect_silent(expect_true(is_path("d:/ab")))
+expect_silent(expect_true(is_path("d:\\")))
+expect_silent(expect_true(is_path("d:\\ab")))
+
+# fs::path_ext_remove(filename) normalizes "C:" to "C:/", which in earlier
+# versions led to the erroneous warning that the filename should not contain ':'.
+expect_warning(
+  expect_false(is_path("D:", require_sep = FALSE)),
+  pattern = "should end in a slash", fixed = TRUE)
+expect_warning(
+  expect_false(is_path("D:abc", require_sep = FALSE)),
+  pattern = "form of relative path", fixed = TRUE)
+
+expect_warning(
+  expect_false(is_path("d:", require_sep = FALSE)),
+  pattern = "should end in a slash", fixed = TRUE)
+expect_warning(
+  expect_false(is_path("d:abc", require_sep = FALSE)),
+  pattern = "form of relative path", fixed = TRUE)
+
 ##### Illegal characters #####
 for(illegal_char in illegal_chars) {
   expect_warning(
@@ -72,7 +99,8 @@ for(illegal_char in illegal_chars) {
     pattern = "should not contain '\"', '*'", fixed = TRUE)
 }
 
-expect_silent(expect_true(is_path("ab:cd/mno/file.txt", require_sep = FALSE)))
+# See also section 'Relative paths' above
+expect_silent(expect_true(is_path("ab:cd/efgh/file.txt", require_sep = FALSE)))
 
 expect_warning(
   expect_false(is_path("abcd/ef:gh/file.txt", require_sep = FALSE)),
@@ -99,10 +127,6 @@ expect_silent(expect_true(is_path("ab:cd", require_sep = FALSE)))
 expect_warning(
   expect_false(is_path("fi:le.txt", require_sep = FALSE)),
   pattern = "should not contain ':'", fixed = TRUE)
-
-# fs::path_ext_remove(filename) normalized "C:" to "C:/" leading to the
-# erroneous warning that the filename should not contain ':'.
-expect_silent(expect_true(is_path("C:", require_sep = FALSE)))
 
 for(control_char in paste0("\005", "\025", "\035", "\177")) {
   expect_warning(

--- a/inst/tinytest/test_is_path.R
+++ b/inst/tinytest/test_is_path.R
@@ -267,12 +267,24 @@ expect_silent(
 # the paths will end in a slash)
 path_in <- fs::path_wd("subdir", "filename.txt")
 if(endsWith(path_in, suffix = "/")) {
-  expect_true(is_path(path_in, require_sep = FALSE))
+  expect_warning(
+    expect_false(is_path(path_in, require_sep = FALSE)),
+    pattern = "should not end with a slash or backslash",
+    strict = TRUE, fixed = TRUE)
 } else {
-  expect_true(is_path(paste0(path_in, "/"), require_sep = FALSE))
+  expect_warning(
+    expect_false(is_path(paste0(path_in, "/"), require_sep = FALSE)),
+    pattern = "should not end with a slash or backslash",
+    strict = TRUE, fixed = TRUE)
 }
 
-expect_true(is_path(paste0(fs::path_wd("subdir", "filename.txt"), "\\")))
+expect_warning(
+  expect_false(is_path(paste0(fs::path_wd("subdir", "filename.txt"), "/"))),
+  pattern = "should not end with a slash or backslash", strict = TRUE, fixed = TRUE)
+
+expect_warning(
+  expect_false(is_path(paste0(fs::path_wd("subdir", "filename.txt"), "\\"))),
+  pattern = "should not end with a slash or backslash", strict = TRUE, fixed = TRUE)
 
 ##### Non-character input #####
 expect_warning(

--- a/inst/tinytest/test_is_path.R
+++ b/inst/tinytest/test_is_path.R
@@ -149,7 +149,7 @@ for(Windows_allowed in c("COM", "COM0", "LPT", "LPT0")) {
 }
 
 ##### Spaces and dots #####
-# Path elements should not end with a space
+# Path components should not end with a space
 expect_true(is_path(fs::path("a b", "def"), require_sep = FALSE))
 
 expect_true(is_path(fs::path("a  b", "def"), require_sep = FALSE))
@@ -191,7 +191,7 @@ expect_warning(
   expect_false(is_path(fs::path("ab", ".", "def"), require_sep = FALSE)),
   pattern = warn_space_dot, fixed = TRUE)
 
-# Path elements should not end with a dot
+# Path components should not end with a dot
 expect_warning(
   expect_false(is_path("ab.", require_sep = FALSE)),
   pattern = "should not end with ' ' or '.'", fixed = TRUE)

--- a/man/is_path.Rd
+++ b/man/is_path.Rd
@@ -27,9 +27,9 @@ directory or a file. Therefore it imposes the following restrictions:
 \item \code{x} should \strong{not} contain the characters \verb{"}, \code{*}, \verb{?}, \code{|}, \code{<}, \code{>}, nor
 any of the control characters (\verb{[:cntrl:]}, with \code{ASCII} octal codes 000
 through 037 and 177,
-see \code{help("regex")}). Although colons (\code{:}) outside a filename are allowed
-by \code{is_path()}, Windows will only allow colons to indicate volume names
-like \verb{C:\\}.
+see \code{help("regex")}).
+\item \code{x} should \strong{not} contain colons (\code{:}) after the first path component
+(Windows only allows colons to indicate volume names like \verb{C:\\}).
 \item path components (i.e., parts separated by file separators \code{/} or \verb{\\\\})
 should \strong{not} be the Windows-reserved terms \code{CON}, \code{PRN}, \code{AUX}, \code{NUL},
 \verb{COM<non-zero digit>}, \verb{LPT<non-zero digit>}, case-insensitive variants of
@@ -117,8 +117,9 @@ is_path(fs::path_wd("abcd.txt")) # TRUE
 is_path(fs::path_wd("abcd.txt.gz")) # TRUE
 is_path(fs::path_wd("abcd.gz")) # TRUE
 
-# ':' is allowed in paths but not in filenames
-is_path(fs::path_wd("ab:cd")) # TRUE
+# ':' is only allowed in the first path component
+is_path("D:/") # TRUE
+is_path(fs::path_wd("ab:cd")) # FALSE, warning about ':'
 is_path(fs::path_wd("ab:cd.txt")) # FALSE, warning about ':'
 
 # Other illegal characters are not allowed in either paths or filenames

--- a/man/is_path.Rd
+++ b/man/is_path.Rd
@@ -43,7 +43,8 @@ implementation does not distinguish those from each other), the part after
 the last slash is considered the filename, which \strong{should} adhere to the
 restrictions listed above (although it \strong{may} contain the Windows-reserved
 terms listed above), and in addition should \strong{not}
-contain a colon (\code{:}) \strong{nor} start with a space or a hyphen (\code{-}).
+contain a colon (\code{:}), \strong{not} start with a space or a hyphen (\code{-}),
+\strong{nor} end with a slash or backslash.
 }
 
 These restrictions on \code{x} consider characters and path components that are
@@ -58,9 +59,10 @@ shell.
 \itemize{
 \item \code{x} does \strong{not} have to contain any file separator if \code{require_sep} is
 \code{FALSE}, such that \code{is_path(x, require_sep = FALSE)} can be used to check
-that filenames only contain allowed characters (given that \code{x} contains a
+that filename \code{x} only contains allowed characters (given that it ends in a
 file extension).
-\item \code{x} might contain trailing file separators, although these might be ignored
+\item \code{x} might contain trailing file separators if it does \strong{not} end in a
+file extension, although these trailing file separators might be ignored
 or removed in some operations (e.g., they are removed by \code{\link[=file.path]{file.path()}} and
 \code{\link[fs:path]{fs::path()}}).
 \item \code{x} might contain successive file separators (e.g., \verb{//} or \verb{\\\\\\\\}): these

--- a/man/is_path.Rd
+++ b/man/is_path.Rd
@@ -128,22 +128,24 @@ is_path(fs::path_wd("ab|cd.txt")) # FALSE, warning about '|'
 
 }
 \seealso{
-\code{\link[fs:path]{fs::path()}} to construct file paths in a platform-independent way,
-\code{\link[fs:path_abs]{fs::path_abs()}} to make paths absolute and normalised, and \code{\link[fs:path_math]{fs::path_math()}}
-for more operations on paths;
-\code{\link[fs:path_sanitize]{fs::path_sanitize()}} to \strong{remove} invalid characters from potential paths;
-\code{\link[utils:file_test]{utils::file_test()}} and references there on checking file existence and
-permissions;
+\code{\link[fs:path]{fs::path()}} to construct file paths in a platform-independent way;
+\code{\link[fs:path_abs]{fs::path_abs()}} to make paths absolute and normalised;
+\code{\link[fs:path_math]{fs::path_math()}} for even more operations on paths;
+\code{\link[fs:path_sanitize]{fs::path_sanitize()}} to \strong{remove} invalid characters from potential paths
+
 \href{https://jessealderliesten.github.io/progutils/reference/create_file_path.html}{\code{progutils::create_file_path()}}
 to create a file path, creating the directory if it does not yet exist;
 \href{https://jessealderliesten.github.io/progutils/reference/create_dir.html}{\code{progutils::create_dir()}}
-to create a directory if it does not yet exist;
+to create a directory if it does not yet exist
+
 \href{https://jessealderliesten.github.io/progutils/reference/get_file_path.html}{\code{progutils::get_file_path()}}
 to check if a file exists and is a unique match to a pattern, and
 \code{\link[fs:file_exists]{fs::file_exists()}} and \code{\link[=list.files]{list.files()}} (which \strong{includes} directories) to do
 so without checking they are a unique match to a pattern;
+\code{\link[utils:file_test]{utils::file_test()}} and references there on checking file existence and
+permissions;
 \code{\link[=file.info]{file.info()}} and \code{\link[=file.access]{file.access()}} to extract information about files or
-directories;
+directories
 
 Section 'Paths in the shell' in the vignette \emph{Git and GitHub} of package
 \code{checkrpkgs} (\code{vignette("git_github", package = "checkrpkgs")}) on paths and

--- a/man/is_path.Rd
+++ b/man/is_path.Rd
@@ -24,6 +24,10 @@ Check that \code{x} is a valid path, possibly containing a valid filename.
 directory or a file. Therefore it imposes the following restrictions:
 \itemize{
 \item \code{x} should be a non-empty \link[=is_character]{character string}
+\item \code{x} should end in a slash if it is only a volume name: \verb{C:\\}, \strong{not} \verb{C:}.
+\item \code{x} should \strong{not} be a relative path of the form \code{D:path} or \code{d:path}:
+such paths are not guaranteed to work with functions like \code{file.create()}.
+Use \code{D:./path} or \code{d:./path} instead.
 \item \code{x} should \strong{not} contain the characters \verb{"}, \code{*}, \verb{?}, \code{|}, \code{<}, \code{>}, nor
 any of the control characters (\verb{[:cntrl:]}, with \code{ASCII} octal codes 000
 through 037 and 177,


### PR DESCRIPTION
### Breaking changes
- `is_path()`: colons are only allowed in the first path component. File names should not end with a slash or backslash. Paths should end in a slash if they only are volume names. Relative paths like `"D:ab/c"` are not allowed.